### PR TITLE
endian: MacOS X support for endian conversion macros

### DIFF
--- a/include/gsm/endian.h
+++ b/include/gsm/endian.h
@@ -1,0 +1,15 @@
+#ifndef GSM_ENDIAN_H
+#define GSM_ENDIAN_H
+
+#if defined(__linux__)
+#  include <endian.h>
+#elif defined(__APPLE__)
+#  include <libkern/OSByteOrder.h>
+
+#  define htobe16(x) OSSwapHostToBigInt16(x)
+#  define htobe32(x) OSSwapHostToBigInt32(x)
+
+#  define be32toh(x) OSSwapBigToHostInt32(x)
+#endif
+
+#endif /* GSM_ENDIAN_H */

--- a/lib/demapping/get_bcch_or_ccch_bursts_impl.cc
+++ b/lib/demapping/get_bcch_or_ccch_bursts_impl.cc
@@ -23,6 +23,7 @@
 #endif
 
 #include <gnuradio/io_signature.h>
+#include <gsm/endian.h>
 #include <gsm/gsmtap.h>
 #include "get_bcch_or_ccch_bursts_impl.h"
 

--- a/lib/demapping/universal_ctrl_chans_demapper_impl.cc
+++ b/lib/demapping/universal_ctrl_chans_demapper_impl.cc
@@ -24,6 +24,7 @@
 
 #include <gnuradio/io_signature.h>
 #include "universal_ctrl_chans_demapper_impl.h"
+#include <gsm/endian.h>
 #include <gsm/gsmtap.h>
 
 namespace gr {

--- a/lib/receiver/receiver_impl.cc
+++ b/lib/receiver/receiver_impl.cc
@@ -38,6 +38,7 @@
 #include <iomanip>
 #include <assert.h>
 #include <boost/scoped_ptr.hpp>
+#include <gsm/endian.h>
 
 //files included for debuging
 //#include "plotting/plotting.hpp"


### PR DESCRIPTION
betohX/htobeX are only available on GNU/Linux.  This change introduces a
header file that maps these functions to the ones available on MacOS X.
