### PR TITLE
2 bug fixes and subslot assignment in universal ctrl channel demapper

### DIFF
--- a/grc/misc_utils/gsm_bursts_printer.xml
+++ b/grc/misc_utils/gsm_bursts_printer.xml
@@ -4,7 +4,7 @@
   <key>gsm_bursts_printer</key>
   <import>import grgsm</import>
   <import>import pmt</import>
-  <make>grgsm.bursts_printer(pmt.intern($prepend_string))</make>
+  <make>grgsm.bursts_printer(pmt.intern($prepend_string), $prepend_fnr)</make>
 
   <param>
     <name>Prepend String</name>
@@ -12,6 +12,20 @@
     <value></value>
     <type>string</type>
     <hide>part</hide>
+  </param>
+  <param>
+    <name>Prepend Frame Number</name>
+    <key>prepend_fnr</key>
+    <value>False</value>
+    <type>bool</type>
+    <option>
+      <name>False</name>
+      <key>False</key>
+    </option>
+    <option>
+      <name>True</name>
+      <key>True</key>
+    </option>
   </param>
 
   <sink>

--- a/include/grgsm/misc_utils/bursts_printer.h
+++ b/include/grgsm/misc_utils/bursts_printer.h
@@ -50,7 +50,7 @@ namespace gr {
        * class. gsm::bursts_printer::make is the public interface for
        * creating new instances.
        */
-      static sptr make(pmt::pmt_t prepend_string);
+      static sptr make(pmt::pmt_t prepend_string, bool prepend_fnr=false);
     };
 
   } // namespace gsm

--- a/lib/demapping/universal_ctrl_chans_demapper_impl.cc
+++ b/lib/demapping/universal_ctrl_chans_demapper_impl.cc
@@ -62,7 +62,7 @@ namespace gr {
         
         for(s=starts_fn_mod51.begin(), ch_type=channel_types.begin();s != starts_fn_mod51.end(); s++)
         {
-            if((*s > 0) and (*s < (51-4)))
+            if((*s >= 0) and (*s <= (51-4)))
             {
                 for(int ii=0; ii<4; ii++){
                     d_starts_fn_mod51[*s+ii] = *s;

--- a/lib/demapping/universal_ctrl_chans_demapper_impl.cc
+++ b/lib/demapping/universal_ctrl_chans_demapper_impl.cc
@@ -101,9 +101,10 @@ namespace gr {
         uint32_t fn51_start = d_starts_fn_mod51[fn_mod51];
         uint32_t fn51_stop = fn51_start + 3;
         uint32_t ch_type = d_channel_types[fn_mod51];
-        header->sub_type = ch_type;
-
+        
         if(header->timeslot==d_timeslot){
+	    header->sub_type = ch_type;
+	    
             if(fn_mod51>=fn51_start && fn_mod51<=fn51_stop)
             {
                 uint32_t ii = fn_mod51 - fn51_start;

--- a/lib/demapping/universal_ctrl_chans_demapper_impl.cc
+++ b/lib/demapping/universal_ctrl_chans_demapper_impl.cc
@@ -55,6 +55,8 @@ namespace gr {
         {
             d_starts_fn_mod51[ii]=0;
             d_channel_types[ii]=0;
+	    d_subslots[ii] = 0;
+	    d_subslots[ii+51] = 0;
         }
         
         std::vector<int>::const_iterator s;
@@ -77,6 +79,48 @@ namespace gr {
                 }
             }
         }
+        
+        std::set<int> distinct_channels(channel_types.begin(), channel_types.end());
+	std::set<int>::iterator it;
+        unsigned int subslot;
+	
+	for (it=distinct_channels.begin(); it != distinct_channels.end(); it++)
+	{
+	    subslot = 0;
+	    for(s=starts_fn_mod51.begin();s != starts_fn_mod51.end(); s++)
+	    {
+		if ((d_channel_types[*s] == *it) and (*s >= 0) and (*s <= (51-4)))
+		{
+		    for(int ii=0; ii<4; ii++)
+		    {
+			d_subslots[*s+ii] = subslot;
+			d_subslots[*s+ii+51] = subslot;
+		    }
+		    subslot++;
+		}
+	    }
+	    
+	    if (*it == GSMTAP_CHANNEL_ACCH or 
+		*it == (GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_SDCCH) or
+		*it == (GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_SDCCH4) or
+		*it == (GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_SDCCH8) or
+		*it == (GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_TCH_F) or
+		*it == (GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_TCH_H)
+	    )
+	    {
+		for(s=starts_fn_mod51.begin();s != starts_fn_mod51.end(); s++)
+		{
+		    if ((d_channel_types[*s] == *it) and (*s >= 0) and (*s <= (51-4)))
+		    {
+			for(int ii=0; ii<4; ii++)
+			{
+			    d_subslots[*s+ii+51] = subslot;
+			}
+			subslot++;
+		    }
+		}
+	    }
+	}
         
         
         message_port_register_in(pmt::mp("bursts"));
@@ -104,6 +148,7 @@ namespace gr {
         
         if(header->timeslot==d_timeslot){
 	    header->sub_type = ch_type;
+	    header->sub_slot = d_subslots[fn_mod51 + (51 * (frame_nr % 2))];
 	    
             if(fn_mod51>=fn51_start && fn_mod51<=fn51_stop)
             {

--- a/lib/demapping/universal_ctrl_chans_demapper_impl.h
+++ b/lib/demapping/universal_ctrl_chans_demapper_impl.h
@@ -33,6 +33,7 @@ namespace gr {
      private:
       unsigned int d_starts_fn_mod51[51];
       unsigned int d_channel_types[51];
+      unsigned int d_subslots[102];
       unsigned int d_timeslot;
       uint32_t d_frame_numbers[4];
       pmt::pmt_t d_bursts[4];

--- a/lib/misc_utils/bursts_printer_impl.cc
+++ b/lib/misc_utils/bursts_printer_impl.cc
@@ -43,8 +43,15 @@ namespace gr {
         gsmtap_hdr * header = (gsmtap_hdr *)pmt::blob_data(header_plus_burst);
         int8_t * burst = (int8_t *)(pmt::blob_data(header_plus_burst))+sizeof(gsmtap_hdr);
         size_t burst_len=pmt::blob_length(header_plus_burst)-sizeof(gsmtap_hdr);
+        uint32_t frame_nr;
         
         std::cout << d_prepend_string;
+        if (d_prepend_fnr) 
+        {
+            frame_nr = be32toh(header->frame_number);
+            std::cout << frame_nr << ":";
+        } 
+
         for(int ii=0; ii<burst_len; ii++)
         {
           std::cout << std::setprecision(1) << static_cast<int>(burst[ii]) << "";
@@ -53,21 +60,22 @@ namespace gr {
     }
      
     bursts_printer::sptr
-    bursts_printer::make(pmt::pmt_t prepend_string)
+    bursts_printer::make(pmt::pmt_t prepend_string, bool prepend_fnr)
     {
       return gnuradio::get_initial_sptr
-        (new bursts_printer_impl(prepend_string));
+        (new bursts_printer_impl(prepend_string, prepend_fnr));
     }
 
     /*
      * The private constructor
      */
-    bursts_printer_impl::bursts_printer_impl(pmt::pmt_t prepend_string)
+    bursts_printer_impl::bursts_printer_impl(pmt::pmt_t prepend_string, bool prepend_fnr)
       : gr::block("bursts_printer",
               gr::io_signature::make(0, 0, 0),
               gr::io_signature::make(0, 0, 0))
     {
         d_prepend_string = prepend_string;
+        d_prepend_fnr = prepend_fnr;
         message_port_register_in(pmt::mp("bursts"));
         set_msg_handler(pmt::mp("bursts"), boost::bind(&bursts_printer_impl::bursts_print, this, _1));
     }

--- a/lib/misc_utils/bursts_printer_impl.h
+++ b/lib/misc_utils/bursts_printer_impl.h
@@ -34,8 +34,9 @@ namespace gr {
      private:
       void bursts_print(pmt::pmt_t burst);
       pmt::pmt_t d_prepend_string;
+      bool d_prepend_fnr;
      public:
-      bursts_printer_impl(pmt::pmt_t prepend_string);
+      bursts_printer_impl(pmt::pmt_t prepend_string, bool prepend_fnr=false);
       ~bursts_printer_impl();
     };
 


### PR DESCRIPTION
Hi @ptrkrysik, 

here are 
- a fix for issue #33 
- a fix for a incorrect condition, which induce that first and last frame were not assigned a channel type 
- an improvement: Added the assignment of subslots for given channels, such that subslots can be used in filtering captures in e.g. wireshark. This makes tracking messages easier.
