### PR TITLE
Correction of TCH and FACCH burst demapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Project setup
 ########################################################################
 cmake_minimum_required(VERSION 2.6)
-project(gr-gsm CXX C)
+project(gr-grgsm CXX C)
 enable_testing()
 
 #set(CMAKE_BUILD_TYPE "Debug")

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ sudo apt-get install wireshark
 ```
 To start *Wireshark* straight to analysis of the *GSMTAP* packets obtained from *gr-gsm*'s airprobe use following command:
 ```
-sudo wireshark -k -Y '!icmp && gsmtap' -i lo
+sudo wireshark -k -f udp -Y gsmtap -i lo
 ````
 
 If you want to avoid the risks caused by running *Wireshark* with root privileges follow this short howto:
@@ -135,6 +135,8 @@ mkdir build
 cmake ..
 make
 sudo make install
+```
+
 
 Installation using Docker
 =========================
@@ -142,6 +144,12 @@ It is possible to install gr-gsm with use of Docker image prepared by Marcel Maa
 This method of installation might be easier for people using distributions where pybombs doesn't work.
 The installation guide is available here:
 https://github.com/marcelmaatkamp/docker-gnuradio-gr-gsm-ptrkrysik
+
+Development
+===========
+New features are accepted through github's pull requests. When creating pull request try to make it adress one topic (addition of a feature x, corretion of bug y).
+
+If you wish to develop something for gr-gsm but don't know exactly what, then look for issues with label "Enhancement". Select one that you feel you are able to complete. After that claim it by commenting in the comment section of the issue. If there is any additional information about gr-gsm needed by you to make completing the task easier - just ask.
 
 Videos
 ======

--- a/apps/airprobe_rtlsdr.grc
+++ b/apps/airprobe_rtlsdr.grc
@@ -513,7 +513,7 @@
     </param>
     <param>
       <key>stop</key>
-      <value>960e6</value>
+      <value>1990e6</value>
     </param>
     <param>
       <key>step</key>

--- a/apps/airprobe_rtlsdr.py
+++ b/apps/airprobe_rtlsdr.py
@@ -2,7 +2,7 @@
 ##################################################
 # Gnuradio Python Flow Graph
 # Title: Airprobe Rtlsdr
-# Generated: Sun Feb 15 11:35:00 2015
+# Generated: Tue Apr 28 22:47:46 2015
 ##################################################
 
 from PyQt4 import Qt
@@ -118,13 +118,13 @@ class airprobe_rtlsdr(gr.top_block, Qt.QWidget):
             def setValue(self, value):
                 super(Qwt.QwtCounter, self).setValue(value)
         self._fc_slider_counter = qwt_counter_pyslot()
-        self._fc_slider_counter.setRange(925e6, 960e6, 2e5)
+        self._fc_slider_counter.setRange(925e6, 1990e6, 2e5)
         self._fc_slider_counter.setNumButtons(2)
         self._fc_slider_counter.setValue(self.fc_slider)
         self._fc_slider_tool_bar.addWidget(self._fc_slider_counter)
         self._fc_slider_counter.valueChanged.connect(self.set_fc_slider)
         self._fc_slider_slider = Qwt.QwtSlider(None, Qt.Qt.Horizontal, Qwt.QwtSlider.BottomScale, Qwt.QwtSlider.BgSlot)
-        self._fc_slider_slider.setRange(925e6, 960e6, 2e5)
+        self._fc_slider_slider.setRange(925e6, 1990e6, 2e5)
         self._fc_slider_slider.setValue(self.fc_slider)
         self._fc_slider_slider.setMinimumWidth(100)
         self._fc_slider_slider.valueChanged.connect(self.set_fc_slider)
@@ -153,6 +153,27 @@ class airprobe_rtlsdr(gr.top_block, Qt.QWidget):
         )
         self.qtgui_freq_sink_x_0.set_update_time(0.10)
         self.qtgui_freq_sink_x_0.set_y_axis(-140, 10)
+        self.qtgui_freq_sink_x_0.enable_autoscale(False)
+        self.qtgui_freq_sink_x_0.enable_grid(False)
+        self.qtgui_freq_sink_x_0.set_fft_average(1.0)
+        
+        labels = ["", "", "", "", "",
+                  "", "", "", "", ""]
+        widths = [1, 1, 1, 1, 1,
+                  1, 1, 1, 1, 1]
+        colors = ["blue", "red", "green", "black", "cyan",
+                  "magenta", "yellow", "dark red", "dark green", "dark blue"]
+        alphas = [1.0, 1.0, 1.0, 1.0, 1.0,
+                  1.0, 1.0, 1.0, 1.0, 1.0]
+        for i in xrange(1):
+            if len(labels[i]) == 0:
+                self.qtgui_freq_sink_x_0.set_line_label(i, "Data {0}".format(i))
+            else:
+                self.qtgui_freq_sink_x_0.set_line_label(i, labels[i])
+            self.qtgui_freq_sink_x_0.set_line_width(i, widths[i])
+            self.qtgui_freq_sink_x_0.set_line_color(i, colors[i])
+            self.qtgui_freq_sink_x_0.set_line_alpha(i, alphas[i])
+        
         self._qtgui_freq_sink_x_0_win = sip.wrapinstance(self.qtgui_freq_sink_x_0.pyqwidget(), Qt.QWidget)
         self.top_layout.addWidget(self._qtgui_freq_sink_x_0_win)
         self.gsm_universal_ctrl_chans_demapper_0 = grgsm.universal_ctrl_chans_demapper(0, ([2,6,12,16,22,26,32,36,42,46]), ([BCCH,CCCH,CCCH,CCCH,CCCH,CCCH,CCCH,CCCH,CCCH,CCCH]))
@@ -166,7 +187,7 @@ class airprobe_rtlsdr(gr.top_block, Qt.QWidget):
         )
         self.gsm_control_channels_decoder_0 = grgsm.control_channels_decoder()
         self.gsm_clock_offset_control_0 = grgsm.clock_offset_control(fc)
-        self.blocks_socket_pdu_0 = blocks.socket_pdu("UDP_CLIENT", "127.0.0.1", "4729", 10000)
+        self.blocks_socket_pdu_0 = blocks.socket_pdu("UDP_CLIENT", "127.0.0.1", "4729", 10000, False)
 
         ##################################################
         # Connections
@@ -176,7 +197,7 @@ class airprobe_rtlsdr(gr.top_block, Qt.QWidget):
         self.connect((self.rtlsdr_source_0, 0), (self.qtgui_freq_sink_x_0, 0))
 
         ##################################################
-        # Message Connections
+        # Asynch Message Connections
         ##################################################
         self.msg_connect(self.gsm_receiver_0, "C0", self.gsm_universal_ctrl_chans_demapper_0, "bursts")
         self.msg_connect(self.gsm_clock_offset_control_0, "ppm", self.gsm_input_0, "ppm_in")

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -22,7 +22,7 @@ add_subdirectory(decryption)
 add_subdirectory(demapping)
 add_subdirectory(receiver)
 add_subdirectory(misc_utils)
-
 install(FILES
-    gsm_block_tree.xml DESTINATION share/gnuradio/grc/blocks
+    gsm_block_tree.xml
+    DESTINATION share/gnuradio/grc/blocks
 )

--- a/include/grgsm/CMakeLists.txt
+++ b/include/grgsm/CMakeLists.txt
@@ -20,14 +20,16 @@
 ########################################################################
 # Install public header files
 ########################################################################
+install(FILES
+    plotting.hpp
+    api.h
+    gsmtap.h
+    DESTINATION include/grgsm
+)
+
 add_subdirectory(decoding)
 add_subdirectory(decryption)
 add_subdirectory(demapping)
 add_subdirectory(receiver)
 add_subdirectory(misc_utils)
 
-install(FILES
-    plotting.hpp
-    api.h
-    gsmtap.h DESTINATION include/grgsm
-)

--- a/include/grgsm/endian.h
+++ b/include/grgsm/endian.h
@@ -9,6 +9,7 @@
 #  define htobe16(x) OSSwapHostToBigInt16(x)
 #  define htobe32(x) OSSwapHostToBigInt32(x)
 
+#  define be16toh(x) OSSwapBigToHostInt16(x)
 #  define be32toh(x) OSSwapBigToHostInt32(x)
 #endif
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,7 +24,7 @@ include(GrPlatform) #define LIB_SUFFIX
 
 include_directories(${Boost_INCLUDE_DIR} receiver)
 link_directories(${Boost_LIBRARY_DIRS})
-list(APPEND gsm_sources
+list(APPEND grgsm_sources
     receiver/receiver_impl.cc
     receiver/receiver_config.cc 
     receiver/viterbi_detector.cc 
@@ -42,9 +42,9 @@ list(APPEND gsm_sources
     misc_utils/message_printer_impl.cc
     misc_utils/tmsi_dumper_impl.cc
     decryption/decryption_impl.cc
-)
+    )
 
-add_library(gnuradio-gsm SHARED ${gsm_sources})
+add_library(gnuradio-gsm SHARED ${grgsm_sources})
 target_link_libraries(gnuradio-gsm ${Boost_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} ${VOLK_LIBRARIES}
 # libraries required by plotting.h - have troubles to be installed by pybombs
 #    boost_iostreams
@@ -69,13 +69,13 @@ install(TARGETS gnuradio-gsm
 
 #include_directories(${CPPUNIT_INCLUDE_DIRS})
 
-#list(APPEND test_gsm_sources
+#list(APPEND test_grgsm_sources
 #    ${CMAKE_CURRENT_SOURCE_DIR}/test_gsm.cc
 #    ${CMAKE_CURRENT_SOURCE_DIR}/qa_gsm.cc
 #    ${CMAKE_CURRENT_SOURCE_DIR}/qa_receiver.cc
 #)
 
-#add_executable(test-gsm ${test_gsm_sources})
+#add_executable(test-gsm ${test_grgsm_sources})
 
 #target_link_libraries(
 #  test-gsm

--- a/lib/decryption/decryption_impl.cc
+++ b/lib/decryption/decryption_impl.cc
@@ -1,17 +1,17 @@
 /* -*- c++ -*- */
-/* 
+/*
  * Copyright 2014 <+YOU OR YOUR COMPANY+>.
- * 
+ *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this software; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -23,12 +23,11 @@
 #endif
 
 #include <gnuradio/io_signature.h>
-#include <grgsm/endian.h>
 #include <grgsm/gsmtap.h>
+#include <grgsm/endian.h>
 #include "decryption_impl.h"
 #include "a5_1_2.h"
-#include "stdio.h"//!!
-#include <algorithm>//!!
+
 
 const uint32_t BURST_SIZE=148;
 
@@ -64,17 +63,17 @@ namespace gr {
     decryption_impl::~decryption_impl()
     {
     }
-    
+
     void decryption_impl::set_k_c(const std::vector<uint8_t> & k_c)
     {
         d_k_c = k_c;
     }
-    
+
     void decryption_impl::decrypt(pmt::pmt_t msg)
     {
         if(d_k_c.size() != 8){
             message_port_pub(pmt::mp("bursts"), msg);
-        } else 
+        } else
         if(d_k_c[0] == 0 && d_k_c[1] == 0 && d_k_c[2] == 0 && d_k_c[3] == 0 &
            d_k_c[4] == 0 && d_k_c[5] == 0 && d_k_c[6] == 0 && d_k_c[7] == 0)
         {
@@ -85,11 +84,11 @@ namespace gr {
             uint8_t AtoBkeystream[114];
             uint8_t BtoAkeystream[114];
             uint8_t * keystream;
-            
+
             pmt::pmt_t header_plus_burst = pmt::cdr(msg);
             gsmtap_hdr * header = (gsmtap_hdr *)pmt::blob_data(header_plus_burst);
             uint8_t * burst_binary = (uint8_t *)(pmt::blob_data(header_plus_burst))+sizeof(gsmtap_hdr);
-            
+
             uint32_t frame_number = be32toh(header->frame_number);
             bool uplink_burst = (be16toh(header->arfcn) & 0x4000) ? true : false;
             uint32_t t1 = frame_number / (26*51);
@@ -98,7 +97,7 @@ namespace gr {
             uint32_t frame_number_mod = (t1 << 11) + (t3 << 5) + t2;
             keysetup(&d_k_c[0], frame_number_mod);
             runA51(AtoBkeystream, BtoAkeystream);
-            
+
             if(uplink_burst){
                 //process uplink burst
                 keystream = BtoAkeystream;
@@ -129,14 +128,13 @@ namespace gr {
             uint8_t new_header_plus_burst[sizeof(gsmtap_hdr)+BURST_SIZE];
             memcpy(new_header_plus_burst, header, sizeof(gsmtap_hdr));
             memcpy(new_header_plus_burst+sizeof(gsmtap_hdr), decrypted_data, BURST_SIZE);
-            
+
             pmt::pmt_t msg_binary_blob = pmt::make_blob(new_header_plus_burst, sizeof(gsmtap_hdr)+BURST_SIZE);
             pmt::pmt_t msg_out = pmt::cons(pmt::PMT_NIL, msg_binary_blob);
-            
+
             message_port_pub(pmt::mp("bursts"), msg_out);
         }
         return;
     }
   } /* namespace gsm */
 } /* namespace gr */
-

--- a/lib/demapping/tch_f_chans_demapper_impl.h
+++ b/lib/demapping/tch_f_chans_demapper_impl.h
@@ -31,13 +31,13 @@ namespace gr {
     class tch_f_chans_demapper_impl : public tch_f_chans_demapper
     {
      private:
-      unsigned int d_starts_fn_mod26[26];
       unsigned int d_timeslot;
-      uint32_t d_frame_numbers[4];
+      uint32_t d_frame_numbers[3][8];
       uint32_t d_frame_numbers_sacch[4];
-      pmt::pmt_t d_bursts[4];
-      bool d_bursts_stolen;
+      pmt::pmt_t d_bursts[3][8];
       pmt::pmt_t d_bursts_sacch[4];
+      bool d_bursts_stolen[3];
+
      public:
       tch_f_chans_demapper_impl(unsigned int timeslot_nr);
       ~tch_f_chans_demapper_impl();

--- a/lib/misc_utils/bursts_printer_impl.cc
+++ b/lib/misc_utils/bursts_printer_impl.cc
@@ -26,6 +26,7 @@
 
 #include <gnuradio/io_signature.h>
 #include <grgsm/gsmtap.h>
+#include <grgsm/endian.h>
 #include <iterator>
 #include <algorithm>
 #include "bursts_printer_impl.h"
@@ -44,13 +45,13 @@ namespace gr {
         int8_t * burst = (int8_t *)(pmt::blob_data(header_plus_burst))+sizeof(gsmtap_hdr);
         size_t burst_len=pmt::blob_length(header_plus_burst)-sizeof(gsmtap_hdr);
         uint32_t frame_nr;
-        
+
         std::cout << d_prepend_string;
-        if (d_prepend_fnr) 
+        if (d_prepend_fnr)
         {
             frame_nr = be32toh(header->frame_number);
             std::cout << frame_nr << ":";
-        } 
+        }
 
         for(int ii=0; ii<burst_len; ii++)
         {
@@ -58,7 +59,7 @@ namespace gr {
         }
         std::cout << std::endl;
     }
-     
+
     bursts_printer::sptr
     bursts_printer::make(pmt::pmt_t prepend_string, bool prepend_fnr)
     {
@@ -79,7 +80,7 @@ namespace gr {
         message_port_register_in(pmt::mp("bursts"));
         set_msg_handler(pmt::mp("bursts"), boost::bind(&bursts_printer_impl::bursts_print, this, _1));
     }
-    
+
     /*
      * Our virtual destructor.
      */
@@ -90,4 +91,3 @@ namespace gr {
 
   } /* namespace gsm */
 } /* namespace gr */
-


### PR DESCRIPTION
Hi @ptrkrysik, 

here is a pull request with the corrections of TCH and FACCH demapping.
The demapping is now done to 3 TCH messages with 8 bursts each. 

I tested the code with some data, SACCH is still working as expected, but FACCH is not decoded (correctly) by the decoder. As you already mentioned, a separate decoder would be an option. 
On the other side, FACCH does not have that high priority for me as getting a TCH decoder working. 

I would rather concentrate on the TCH decoder as the next step, and just open an issue about it, so we can keep track of this improvement. 