### PR TITLE
CX channel hopping

### DIFF
--- a/grc/gsm_block_tree.xml
+++ b/grc/gsm_block_tree.xml
@@ -13,6 +13,7 @@
     <cat>
       <name>Receiver</name>
       <block>gsm_receiver</block>
+      <block>gsm_cx_channel_hopper</block>
       <block>gsm_fcch_burst_tagger</block>
       <block>gsm_sch_detector</block>
       <block>gsm_fcch_detector</block>

--- a/grc/receiver/CMakeLists.txt
+++ b/grc/receiver/CMakeLists.txt
@@ -23,5 +23,6 @@ install(FILES
     gsm_fcch_burst_tagger.xml
     gsm_sch_detector.xml
     gsm_fcch_detector.xml
+    gsm_cx_channel_hopper.xml
     gsm_clock_offset_control.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/receiver/gsm_cx_channel_hopper.xml
+++ b/grc/receiver/gsm_cx_channel_hopper.xml
@@ -7,7 +7,8 @@
   <param>
     <name>MA</name>
     <key>ma</key>
-    <type>int</type>
+    <value>[]</value>
+    <type>int_vector</type>
   </param>
 
   <param>

--- a/grc/receiver/gsm_cx_channel_hopper.xml
+++ b/grc/receiver/gsm_cx_channel_hopper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<block>
+  <name>CX channel hopper</name>
+  <key>gsm_cx_channel_hopper</key>
+  <import>import grgsm</import>
+  <make>grgsm.cx_channel_hopper($ma, $maio, $hsn)</make>
+  <param>
+    <name>MA</name>
+    <key>ma</key>
+    <type>int</type>
+  </param>
+
+  <param>
+    <name>MAIO</name>
+    <key>maio</key>
+    <type>int</type>
+  </param>
+
+  <param>
+    <name>HSN</name>
+    <key>hsn</key>
+    <type>int</type>
+  </param>
+
+  <sink>
+    <name>CX</name>
+    <type>message</type>
+  </sink>
+
+  <source>
+    <name>bursts</name>
+    <type>message</type>
+  </source>
+</block>

--- a/include/grgsm/receiver/CMakeLists.txt
+++ b/include/grgsm/receiver/CMakeLists.txt
@@ -22,5 +22,6 @@
 ########################################################################
 install(FILES
     clock_offset_control.h
+    cx_channel_hopper.h
     receiver.h DESTINATION include/grgsm/receiver
 )

--- a/include/grgsm/receiver/cx_channel_hopper.h
+++ b/include/grgsm/receiver/cx_channel_hopper.h
@@ -26,6 +26,7 @@
 
 #include <grgsm/api.h>
 #include <gnuradio/block.h>
+#include <vector>
 
 namespace gr {
   namespace gsm {
@@ -48,7 +49,7 @@ namespace gr {
        * class. gsm::cx_channel_hopper::make is the public interface for
        * creating new instances.
        */
-      static sptr make(int ma, int maio, int hsn);
+      static sptr make(const std::vector<int> &ma, int maio, int hsn);
     };
 
   } // namespace gsm

--- a/include/grgsm/receiver/cx_channel_hopper.h
+++ b/include/grgsm/receiver/cx_channel_hopper.h
@@ -1,0 +1,58 @@
+/* -*- c++ -*- */
+/* @file
+ * @author Piotr Krysik <ptrkrysik@gmail.com>
+ * @section LICENSE
+ * 
+ * Gr-gsm is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * Gr-gsm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-gsm; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ * 
+ */
+
+
+#ifndef INCLUDED_GSM_CX_CHANNEL_HOPPER_H
+#define INCLUDED_GSM_CX_CHANNEL_HOPPER_H
+
+#include <grgsm/api.h>
+#include <gnuradio/block.h>
+
+namespace gr {
+  namespace gsm {
+
+    /*!
+     * \brief <+description of block+>
+     * \ingroup gsm
+     *
+     */
+    class GSM_API cx_channel_hopper : virtual public gr::block
+    {
+     public:
+      typedef boost::shared_ptr<cx_channel_hopper> sptr;
+
+      /*!
+       * \brief Return a shared_ptr to a new instance of gsm::cx_channel_hopper.
+       *
+       * To avoid accidental use of raw pointers, gsm::cx_channel_hopper's
+       * constructor is in a private implementation
+       * class. gsm::cx_channel_hopper::make is the public interface for
+       * creating new instances.
+       */
+      static sptr make(int ma, int maio, int hsn);
+    };
+
+  } // namespace gsm
+} // namespace gr
+
+#endif /* INCLUDED_GSM_CX_CHANNEL_HOPPER_H */
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND grgsm_sources
     receiver/viterbi_detector.cc 
     receiver/sch.c
     receiver/clock_offset_control_impl.cc
+    receiver/cx_channel_hopper_impl.cc
     misc_utils/bursts_printer_impl.cc
     misc_utils/extract_system_info_impl.cc
     demapping/universal_ctrl_chans_demapper_impl.cc
@@ -48,8 +49,7 @@ list(APPEND grgsm_sources
     misc_utils/tmsi_dumper_impl.cc
     misc_utils/burst_sink_impl.cc
     misc_utils/burst_source_impl.cc
-    decryption/decryption_impl.cc
-    )
+    decryption/decryption_impl.cc )
 
 add_library(gnuradio-gsm SHARED ${grgsm_sources})
 target_link_libraries(gnuradio-gsm ${Boost_LIBRARIES} ${GNURADIO_RUNTIME_LIBRARIES} ${VOLK_LIBRARIES}

--- a/lib/receiver/cx_channel_hopper_impl.cc
+++ b/lib/receiver/cx_channel_hopper_impl.cc
@@ -1,0 +1,65 @@
+/* -*- c++ -*- */
+/* @file
+ * @author Piotr Krysik <ptrkrysik@gmail.com>
+ * @section LICENSE
+ * 
+ * Gr-gsm is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * Gr-gsm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-gsm; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ * 
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "cx_channel_hopper_impl.h"
+
+namespace gr {
+  namespace gsm {
+
+    cx_channel_hopper::sptr
+    cx_channel_hopper::make(int ma, int maio, int hsn)
+    {
+      return gnuradio::get_initial_sptr
+        (new cx_channel_hopper_impl(ma, maio, hsn));
+    }
+
+    /*
+     * The private constructor
+     */
+    cx_channel_hopper_impl::cx_channel_hopper_impl(int ma, int maio, int hsn)
+      : gr::block("cx_channel_hopper",
+              gr::io_signature::make(0, 0, 0),
+              gr::io_signature::make(0, 0, 0))
+    {
+      d_ma = ma;
+      d_maio = maio;
+      d_hsn = hsn;
+
+      message_port_register_in(pmt::mp("CX"));
+      message_port_register_out(pmt::mp("bursts"));
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    cx_channel_hopper_impl::~cx_channel_hopper_impl()
+    {
+    }
+
+  } /* namespace gsm */
+} /* namespace gr */
+

--- a/lib/receiver/cx_channel_hopper_impl.h
+++ b/lib/receiver/cx_channel_hopper_impl.h
@@ -31,12 +31,16 @@ namespace gr {
     class cx_channel_hopper_impl : public cx_channel_hopper
     {
      private:
-      int d_ma;
-      int d_maio;
-      int d_hsn;
+      std::vector<int> d_ma; // Mobile Allocation list. Contains all channels that are used while channel hopping
+      int d_maio; // Mobile Allocation Index Offset
+      int d_hsn; // Hopping Sequence Number
+      int d_narfcn; // Length of d_ma
+
+      int calculate_ma_sfh(int maio, int hsn, int n, int fn);
+      void assemble_bursts(pmt::pmt_t msg);
 
      public:
-      cx_channel_hopper_impl(int ma, int maio, int hsn);
+      cx_channel_hopper_impl(const std::vector<int> &ma, int maio, int hsn);
       ~cx_channel_hopper_impl();
     };
 

--- a/lib/receiver/cx_channel_hopper_impl.h
+++ b/lib/receiver/cx_channel_hopper_impl.h
@@ -1,0 +1,47 @@
+/* -*- c++ -*- */
+/* @file
+ * @author Piotr Krysik <ptrkrysik@gmail.com>
+ * @section LICENSE
+ * 
+ * Gr-gsm is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * Gr-gsm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-gsm; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ * 
+ */
+
+#ifndef INCLUDED_GSM_CX_CHANNEL_HOPPER_IMPL_H
+#define INCLUDED_GSM_CX_CHANNEL_HOPPER_IMPL_H
+
+#include <grgsm/receiver/cx_channel_hopper.h>
+
+namespace gr {
+  namespace gsm {
+
+    class cx_channel_hopper_impl : public cx_channel_hopper
+    {
+     private:
+      int d_ma;
+      int d_maio;
+      int d_hsn;
+
+     public:
+      cx_channel_hopper_impl(int ma, int maio, int hsn);
+      ~cx_channel_hopper_impl();
+    };
+
+  } // namespace gsm
+} // namespace gr
+
+#endif /* INCLUDED_GSM_CX_CHANNEL_HOPPER_IMPL_H */
+

--- a/swig/grgsm_swig.i
+++ b/swig/grgsm_swig.i
@@ -10,6 +10,7 @@
 %{
 #include "grgsm/receiver/receiver.h"
 #include "grgsm/receiver/clock_offset_control.h"
+#include "grgsm/receiver/cx_channel_hopper.h"
 #include "grgsm/decoding/control_channels_decoder.h"
 #include "grgsm/decoding/tch_f_decoder.h"
 #include "grgsm/decryption/decryption.h"
@@ -30,7 +31,8 @@
 GR_SWIG_BLOCK_MAGIC2(gsm, receiver);
 %include "grgsm/receiver/clock_offset_control.h"
 GR_SWIG_BLOCK_MAGIC2(gsm, clock_offset_control);
-
+%include "grgsm/receiver/cx_channel_hopper.h"
+GR_SWIG_BLOCK_MAGIC2(gsm, cx_channel_hopper);
 
 %include "grgsm/decoding/control_channels_decoder.h"
 GR_SWIG_BLOCK_MAGIC2(gsm, control_channels_decoder);
@@ -61,4 +63,3 @@ GR_SWIG_BLOCK_MAGIC2(gsm, controlled_const_source_f);
 GR_SWIG_BLOCK_MAGIC2(gsm, message_printer);
 %include "grgsm/misc_utils/tmsi_dumper.h"
 GR_SWIG_BLOCK_MAGIC2(gsm, tmsi_dumper);
-


### PR DESCRIPTION
Added a new block, which must be placed after the GSM Receiver block in order to correctly assemble bursts on hopping channels. Resolves issue https://github.com/ptrkrysik/gr-gsm/issues/51.