### PR TITLE
Bugfix c++ 11 array init

### DIFF
--- a/lib/decoding/tch_f_decoder_impl.cc
+++ b/lib/decoding/tch_f_decoder_impl.cc
@@ -57,6 +57,8 @@ namespace gr {
             throw std::runtime_error("TCH/F Decoder: can't open file\n");
         }
 
+        const unsigned char amr_nb_magic[6] = { 0x23, 0x21, 0x41, 0x4d, 0x52, 0x0a };
+
         if (d_tch_mode == MODE_SPEECH_EFR)
         {
             fwrite(amr_nb_magic, 1, 6, d_speech_file);

--- a/lib/decoding/tch_f_decoder_impl.h
+++ b/lib/decoding/tch_f_decoder_impl.h
@@ -53,7 +53,6 @@ namespace gr {
                 FILE * d_speech_file;
                 enum tch_mode d_tch_mode;
                 void decode(pmt::pmt_t msg);
-                const unsigned char amr_nb_magic[6] = { 0x23, 0x21, 0x41, 0x4d, 0x52, 0x0a };
             public:
                 tch_f_decoder_impl(tch_mode mode, const std::string &file);
                 ~tch_f_decoder_impl();


### PR DESCRIPTION
Hi @ptrkrysik , 

here is a quick fix for the compilation failure on raspi / parrot, reported in issue #65 and #45 
Moved array initialization to constructor.