### PR TITLE
misc_utils: Include endian.h from grgsm

### DIFF
--- a/lib/misc_utils/extract_immediate_assignment_impl.cc
+++ b/lib/misc_utils/extract_immediate_assignment_impl.cc
@@ -28,7 +28,7 @@
 #include <grgsm/gsmtap.h>
 #include <unistd.h>
 #include <map>
-#include <endian.h>
+#include <grgsm/endian.h>
 #include <boost/foreach.hpp>
 
 #include "extract_immediate_assignment_impl.h"

--- a/lib/misc_utils/extract_system_info_impl.cc
+++ b/lib/misc_utils/extract_system_info_impl.cc
@@ -31,7 +31,7 @@
 #include <iterator>
 #include <algorithm>
 #include <iostream>
-#include <endian.h>
+#include <grgsm/endian.h>
 #include <boost/foreach.hpp>
 extern "C" {
     #include <osmocom/gsm/gsm48_ie.h>


### PR DESCRIPTION
MacOS X does not have endian.h and the build will fail unless
grgsm/endian.h is used.