### PR TITLE
apps/CMakeLists.txt: fix bogus target

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -45,6 +45,6 @@ GR_PYTHON_INSTALL(
 #    ${CMAKE_CURRENT_BINARY_DIR}/airprobe_rtlsdr.py
     airprobe_rtlsdr.py
     airprobe_decode.py
-    airprobe_rtlsdr_capture
+    airprobe_rtlsdr_capture.py
     DESTINATION bin
 )


### PR DESCRIPTION
the airprobe_rtlsdr_capture target from apps/CMakeLists.txt is missing a .py extension.
the build therefore fails (at least on OSX) with the following error message

make[2]: *** No rule to make target `../apps/airprobe_rtlsdr_capture', needed by `apps/airprobe_rtlsdr_capture.exe'.  Stop.

This change fixes it