### PR TITLE
Allow user to specify band in gsm_wideband_input.py/.xml

### DIFF
--- a/grc/receiver/gsm_wideband_input.xml
+++ b/grc/receiver/gsm_wideband_input.xml
@@ -9,6 +9,7 @@
     fc=$fc,
     samp_rate_in=$samp_rate_in,
     ca=$cell_allocation,
+    band=$band,
 )</make>
   <callback>set_ppm($ppm)</callback>
   <callback>set_osr($osr)</callback>
@@ -36,6 +37,45 @@
     <hide>part</hide>
   </param>
   <param>
+    <name>Band</name>
+    <key>band</key>
+    <value>E-GSM</value>
+    <type>string</type>
+    <hide>part</hide>
+    <option>
+      <name>P-GSM (1-124)</name>
+      <key>P-GSM</key>
+    </option>
+    <option>
+      <name>DCS1800 (512-885)</name>
+      <key>DCS1900</key>
+    </option>
+    <option>
+      <name>PCS1900 (512-810)</name>
+      <key>PCS1900</key>
+    </option>
+    <option>
+      <name>E-GSM (975-1023)</name>
+      <key>E-GSM</key>
+    </option>
+    <option>
+      <name>R-GSM (955-1023)</name>
+      <key>R-GSM</key>
+    </option>
+    <option>
+      <name>GSM450 (259-293)</name>
+      <key>GSM450</key>
+    </option>
+    <option>
+      <name>GSM480 (306-340)</name>
+      <key>GSM480</key>
+    </option> 
+    <option>
+      <name>GSM850 (128-251)</name>
+      <key>GSM850</key>
+    </option>
+  </param>
+  <param>
     <name>Cell allocation</name>
     <key>cell_allocation</key>
     <value>[]</value>
@@ -57,6 +97,7 @@
     <hide>part</hide>
   </param>
   <check>$num_streams &gt;= 0</check>
+  <check>$cell_allocation and all(grgsm.arfcn.is_valid_arfcn(c, $band) for c in $cell_allocation)</check>
   <sink>
     <name>in</name>
     <type>complex</type>

--- a/python/receiver/gsm_wideband_input.py
+++ b/python/receiver/gsm_wideband_input.py
@@ -15,7 +15,7 @@ import grgsm.arfcn as arfcn
 import grgsm
 
 class gsm_wideband_input(grgsm.hier_block):
-    def __init__(self, ppm=0, osr=4, fc=925.2e6, samp_rate_in=20e6, ca=[]):
+    def __init__(self, ppm=0, osr=4, fc=925.2e6, samp_rate_in=20e6, ca=[], band='P-GSM'):
         self.num_streams = len(ca)
         grgsm.hier_block.__init__(
             self, "GSM wideband input adaptor",
@@ -34,7 +34,7 @@ class gsm_wideband_input(grgsm.hier_block):
         self.blocks_fir_filters = {}
         self.blocks_resamplers = {}
         self.blocks_ocs = {}
-        self.band = band = 'E-GSM'  # TODO make selectable
+        self.band = band
 
         ##################################################
         # Variables


### PR DESCRIPTION
This patch fixes a todo in gsm_wideband_input.py and adds a drop-down chooser to the GRC block to pick the band being received. A check that the cell allocation array is present and valid has been added.