### PR TITLE
Alteration to the method used for calculating MNC.

### DIFF
--- a/lib/misc_utils/extract_system_info_impl.cc
+++ b/lib/misc_utils/extract_system_info_impl.cc
@@ -75,7 +75,7 @@ namespace gr {
             info.cell_id = (msg_elements[3]<<8)+msg_elements[4];         //take cell id
             info.lac = (msg_elements[8]<<8)+msg_elements[9];             //take lac
             info.mcc =  ((msg_elements[5] & 0xF)  * 100) + (((msg_elements[5] & 0xF0) >> 4) * 10) + ((msg_elements[6] & 0xF)); // take mcc
-            info.mnc = (msg_elements[7] & 0xF) * 10 + (msg_elements[7]>>4); //take mnc
+            info.mnc = ((msg_elements[7] & 0xF) * 100) + (((msg_elements[7] & 0xF0) >>4) * 10) + ((msg_elements[8] & 0xF)); //take mnc
             info.ccch_conf = (msg_elements[10] & 0x7); // ccch_conf
             
             boost::mutex::scoped_lock lock(extract_mutex);
@@ -91,7 +91,7 @@ namespace gr {
             info.pwr_db = header->signal_dbm;
             info.lac = (msg_elements[6]<<8)+msg_elements[7];            //take lac
             info.mcc =  ((msg_elements[3] & 0xF) * 100) + (((msg_elements[3] & 0xF0) >> 4) * 10) + ((msg_elements[4] & 0xF)); // take mcc
-            info.mnc = (msg_elements[5] & 0xF) * 10 + (msg_elements[5]>>4); //take mnc
+            info.mnc = ((msg_elements[5] & 0xF) * 100) + (((msg_elements[5] & 0xF0) >>4) * 10) + ((msg_elements[6] & 0xF)); //take mnc
             
             boost::mutex::scoped_lock lock(extract_mutex);
             if(d_c0_channels.find(info.id) != d_c0_channels.end()){


### PR DESCRIPTION
Alters the method used for calculating the MNC to match the way MCC is calculated.

If I'm being honest, I'm not _sure_ that this is actually the right answer, @ptrkrysik, but it _does_ change gr-gsm such that it gives me the correct MNC for towers nearby me.  Before this change, the gathered MNC was off by an order of magnitude (`41` rather than `410`), so I made some guesses and changed the MNC calculation to match the MCC and now do receive the correct answer.