### PR TITLE
Fix MNC calculation to match the implementation used by Wireshark.

### DIFF
--- a/include/grgsm/misc_utils/extract_system_info.h
+++ b/include/grgsm/misc_utils/extract_system_info.h
@@ -54,8 +54,8 @@ namespace gr {
       virtual std::vector<int> get_pwrs() = 0;
       virtual std::vector<int> get_lac() = 0;
       virtual std::vector<int> get_cell_id() = 0;
-      virtual std::vector<int> get_mcc() = 0;
-      virtual std::vector<int> get_mnc() = 0;
+      virtual std::vector<std::string> get_mcc();
+      virtual std::vector<std::string> get_mnc();
       virtual std::vector<int> get_ccch_conf() = 0;
       virtual std::vector<int> get_cell_arfcns(int chan_id) = 0;
       virtual std::vector<int> get_neighbours(int chan_id) = 0;

--- a/lib/misc_utils/extract_system_info_impl.cc
+++ b/lib/misc_utils/extract_system_info_impl.cc
@@ -75,7 +75,7 @@ namespace gr {
             info.cell_id = (msg_elements[3]<<8)+msg_elements[4];         //take cell id
             info.lac = (msg_elements[8]<<8)+msg_elements[9];             //take lac
             info.mcc =  ((msg_elements[5] & 0xF)  * 100) + (((msg_elements[5] & 0xF0) >> 4) * 10) + ((msg_elements[6] & 0xF)); // take mcc
-            info.mnc = (msg_elements[7] & 0xF) * 10 + (msg_elements[7]>>4); //take mnc
+            info.mnc = ((msg_elements[7] & 0xF) * 100) + (((msg_elements[7] & 0xF0) >>4) * 10) + ((msg_elements[6] & 0xF0) >> 4); //take mnc
             info.ccch_conf = (msg_elements[10] & 0x7); // ccch_conf
             
             boost::mutex::scoped_lock lock(extract_mutex);
@@ -91,7 +91,7 @@ namespace gr {
             info.pwr_db = header->signal_dbm;
             info.lac = (msg_elements[6]<<8)+msg_elements[7];            //take lac
             info.mcc =  ((msg_elements[3] & 0xF) * 100) + (((msg_elements[3] & 0xF0) >> 4) * 10) + ((msg_elements[4] & 0xF)); // take mcc
-            info.mnc = (msg_elements[5] & 0xF) * 10 + (msg_elements[5]>>4); //take mnc
+            info.mnc = ((msg_elements[5] & 0xF) * 100) + (((msg_elements[5] & 0xF0) >>4) * 10) + ((msg_elements[4] & 0xF0) >> 4); //take mnc
             
             boost::mutex::scoped_lock lock(extract_mutex);
             if(d_c0_channels.find(info.id) != d_c0_channels.end()){

--- a/lib/misc_utils/extract_system_info_impl.h
+++ b/lib/misc_utils/extract_system_info_impl.h
@@ -37,8 +37,8 @@ namespace gr {
         unsigned int arfcn;
         unsigned int lac;
         unsigned int cell_id;
-        unsigned int mcc;
-        unsigned int mnc;
+        std::string mcc;
+        std::string mnc;
         unsigned int ccch_conf;
         std::set<int> neighbour_cells;
         std::set<int> cell_arfcns;
@@ -52,8 +52,8 @@ namespace gr {
             arfcn = info.arfcn;
             lac = (info.lac!=0) ? info.lac : lac;
             cell_id = (info.cell_id!=0) ? info.cell_id : cell_id;
-            mcc = (info.mcc!=0) ? info.mcc : mcc;
-            mnc = (info.mnc!=0) ? info.mnc : mnc;
+            mcc = (info.mcc!="") ? info.mcc : mcc;
+            mnc = (info.mnc!="") ? info.mnc : mnc;
             ccch_conf = (info.ccch_conf!=-1) ? info.ccch_conf : ccch_conf;
         }
     };
@@ -77,6 +77,8 @@ namespace gr {
     {
      private:
       void process_bursts(pmt::pmt_t burst);
+      std::string extract_mcc_from_plmn(uint8_t *);
+      std::string extract_mnc_from_plmn(uint8_t *);
       void process_sysinfo(pmt::pmt_t msg);
       chan_info_map d_c0_channels;
       bool after_reset;
@@ -87,8 +89,8 @@ namespace gr {
       virtual std::vector<int> get_pwrs();
       virtual std::vector<int> get_lac();
       virtual std::vector<int> get_cell_id();
-      virtual std::vector<int> get_mcc();
-      virtual std::vector<int> get_mnc();
+      virtual std::vector<std::string> get_mcc();
+      virtual std::vector<std::string> get_mnc();
       virtual std::vector<int> get_ccch_conf();
       virtual std::vector<int> get_cell_arfcns(int chan_id);
       virtual std::vector<int> get_neighbours(int chan_id);


### PR DESCRIPTION
I've now double-checked this using `grgsm_livemon` and compared the bytes used by wireshark with those used by `extract_system_info_impl.cc`; this appears to be true:

It's a little mysterious to me, but it appears that, when given six bytes:

    AB CD EF

These digits correspond with the following digits of the MCC and MNC:

    *MCC*: BAC
    *MNC*: FED