### PR TITLE
Added BER calculator and a little change in the control_channels_demapper to get essential outputs for BER calculator.

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -25,5 +25,6 @@ add_subdirectory(flow_control)
 add_subdirectory(misc_utils)
 install(FILES
     gsm_block_tree.xml
-    grgsm_msg_to_tag.xml DESTINATION share/gnuradio/grc/blocks
+    grgsm_msg_to_tag.xml
+    grgsm_BER_calc.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/decoding/gsm_control_channels_decoder.xml
+++ b/grc/decoding/gsm_control_channels_decoder.xml
@@ -13,4 +13,9 @@
     <type>message</type>
     <optional>1</optional>
   </source>
+  <source>
+    <name>de</name>
+    <type>message</type>
+    <optional>1</optional>
+  </source>
 </block>

--- a/grc/grgsm_BER_calc.xml
+++ b/grc/grgsm_BER_calc.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<block>
+  <name>GSM BER calculator</name>
+  <key>grgsm_BER_calc</key>
+  <category>[grgsm]</category>
+  <import>import grgsm</import>
+  <make>grgsm.BER_calc()</make>
+
+  <!-- Make one 'sink' node per input. Sub-nodes:
+       * name (an identifier for the GUI)
+       * type
+       * vlen
+       * optional (set to 1 for optional inputs) -->
+  <sink>
+    <name>de</name>
+    <type>message</type>
+    <optional>1</optional>
+  </sink>
+ <source>
+    <name>BER</name>
+    <type>float</type>
+  </source>
+</block>

--- a/include/grgsm/BER_calc.h
+++ b/include/grgsm/BER_calc.h
@@ -1,0 +1,65 @@
+/* -*- c++ -*- */
+/* @file
+ * @author Piotr Krysik <ptrkrysik@gmail.com>
+ * @section LICENSE
+ * 
+ * Gr-gsm is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * Gr-gsm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-gsm; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ * 
+ */
+
+
+#ifndef INCLUDED_GRGSM_BER_CALC_H
+#define INCLUDED_GRGSM_BER_CALC_H
+
+#include <grgsm/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace grgsm {
+
+    /*!
+     * \brief It is to calculate the BER of the demodulated bits. This is done by:
+     *  1) encode the decoded bits of control channels
+     *  2) count the difference between demodulated and encoded bits
+     *
+     * \attention The decoded bits comming from "control_channels_decoder" are parity checked,
+     * hence they are captured correctly. Therefore, by encoding them again, the correct modulated
+     * bits can be obtained.
+     *
+     * \ingroup grgsm
+     *
+     */
+    class GRGSM_API BER_calc : virtual public gr::block
+    {
+     public:
+      typedef boost::shared_ptr<BER_calc> sptr;
+
+      /*!
+       * \brief Return a shared_ptr to a new instance of grgsm::BER_calc.
+       *
+       * To avoid accidental use of raw pointers, grgsm::BER_calc's
+       * constructor is in a private implementation
+       * class. grgsm::BER_calc::make is the public interface for
+       * creating new instances.
+       */
+      static sptr make();
+    };
+
+  } // namespace grgsm
+} // namespace gr
+
+#endif /* INCLUDED_GRGSM_BER_CALC_H */
+

--- a/include/grgsm/CMakeLists.txt
+++ b/include/grgsm/CMakeLists.txt
@@ -24,7 +24,8 @@ install(FILES
     plotting.hpp
     api.h
     gsmtap.h
-    msg_to_tag.h DESTINATION include/grgsm
+    msg_to_tag.h
+    BER_calc.h DESTINATION include/grgsm
 )
 
 add_subdirectory(decoding)

--- a/lib/BER_calc_impl.cc
+++ b/lib/BER_calc_impl.cc
@@ -1,0 +1,110 @@
+/* -*- c++ -*- */
+/* @file
+ * @author Piotr Krysik <ptrkrysik@gmail.com>
+ * @section LICENSE
+ * 
+ * Gr-gsm is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * Gr-gsm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-gsm; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ * 
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "BER_calc_impl.h"
+
+namespace gr {
+  namespace grgsm {
+
+    BER_calc::sptr
+    BER_calc::make()
+    {
+      return gnuradio::get_initial_sptr
+        (new BER_calc_impl());
+    }
+
+    /*
+     * The private constructor
+     */
+    BER_calc_impl::BER_calc_impl()
+      : gr::block("BER_calc",
+              gr::io_signature::make(0, 0, 0),
+              gr::io_signature::make(1, 1, sizeof(float))),
+        BER(0),
+        totalBits(0)
+    {
+        set_max_output_buffer(1);
+        set_max_output_buffer(1);
+        //setup input/output ports
+        message_port_register_in(pmt::mp("de"));
+        set_msg_handler(pmt::mp("de"), boost::bind(&BER_calc_impl::ber_calc, this, _1));
+
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    BER_calc_impl::~BER_calc_impl()
+    {
+    }
+
+    void BER_calc_impl::ber_calc(pmt::pmt_t msg)
+    {
+        demod = car(msg);
+        decod = cdr(msg);
+
+        unsigned char *dmod_bits = (unsigned char*) pmt::blob_data(demod);
+        unsigned char *dcod_bits = (unsigned char*) pmt::blob_data(decod);
+
+        GSMFrameCoder enc;
+        char *inbin[3];
+        inbin[0] = NULL;
+        inbin[1] = "-b";
+        inbin[2] = (char*)dcod_bits;
+
+        BitVector1 *encoded_bits = enc.func(3, inbin);
+        // computing BER
+        uint errs=0;
+        for (int ss=0; ss<4 ; ss++)
+        {
+            for (int kk=0; kk<iBLOCK_SIZE; kk++)
+            {
+                if ((encoded_bits[ss][kk] != dmod_bits[ss*iBLOCK_SIZE+kk]))
+                    errs++;
+            }
+        }
+        BER = (BER*totalBits+float(errs))/(CONV_SIZE+totalBits);
+        totalBits += CONV_SIZE;
+//        cout << "BER= \n" << BER << endl;
+    }
+
+    int
+    BER_calc_impl::general_work(int noutput_items,
+                    gr_vector_int &ninput_items,
+                    gr_vector_const_void_star &input_items,
+                    gr_vector_void_star &output_items)
+    {
+        float * out = (float*) output_items[0];
+
+        memcpy(out,&BER, sizeof(float));
+//        cout << "BER= \n" << BER << endl;
+
+        return 1;
+    }
+  } /* namespace grgsm */
+} /* namespace gr */
+

--- a/lib/BER_calc_impl.h
+++ b/lib/BER_calc_impl.h
@@ -1,0 +1,62 @@
+/* -*- c++ -*- */
+/* @file
+ * @author Piotr Krysik <ptrkrysik@gmail.com>
+ * @section LICENSE
+ * 
+ * Gr-gsm is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * Gr-gsm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with gr-gsm; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ * 
+ */
+
+#ifndef INCLUDED_GRGSM_BER_CALC_IMPL_H
+#define INCLUDED_GRGSM_BER_CALC_IMPL_H
+
+#include <grgsm/BER_calc.h>
+#include "decoding/cch.h"
+#include "GSMFrameCoder.h"
+
+using namespace std;
+
+namespace gr {
+  namespace grgsm {
+
+  class BER_calc_impl : public BER_calc
+  {
+  private:
+      // Nothing to declare in this block.
+
+  public:
+      BER_calc_impl();
+      ~BER_calc_impl();
+      int general_work(int noutput_items,
+               gr_vector_int &ninput_items,
+               gr_vector_const_void_star &input_items,
+               gr_vector_void_star &output_items);
+  private:
+      //      char [CONV_SIZE+DATA_BLOCK_SIZE];
+      pmt::pmt_t demod;
+      pmt::pmt_t decod;
+      void ber_calc(pmt::pmt_t msg);
+
+      float BER;
+      uint totalBits;
+
+    };
+
+  } // namespace grgsm
+} // namespace gr
+
+#endif /* INCLUDED_GRGSM_BER_CALC_IMPL_H */
+

--- a/lib/BitVector1.cpp
+++ b/lib/BitVector1.cpp
@@ -1,0 +1,580 @@
+/*
+* Copyright 2008, 2009 Free Software Foundation, Inc.
+*
+* This software is distributed under the terms of the GNU Affero Public License.
+* See the COPYING file in the main directory for details.
+*
+* This use of this software may be subject to additional restrictions.
+* See the LEGAL file in the main directory for details.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+
+
+
+#include "BitVector1.h"
+#include <iostream>
+
+using namespace std;
+
+
+/**
+  Apply a Galois polymonial to a binary seqeunce.
+  @param val The input sequence.
+  @param poly The polynomial.
+  @param order The order of the polynomial.
+  @return Single-bit result.
+*/
+unsigned applyPoly(uint64_t val, uint64_t poly, unsigned order)
+{
+	uint64_t prod = val & poly;
+	unsigned sum = prod;
+	for (unsigned i=1; i<order; i++) sum ^= prod>>i;
+	return sum & 0x01;
+}
+
+
+
+
+
+
+BitVector1::BitVector1(std::string valString)
+    :Vector1<char>(valString.size())
+{
+	uint32_t accum = 0;
+	for (size_t i=0; i<size(); i++) {
+		accum <<= 1;
+		if (valString[i]=='1') accum |= 0x01;
+		mStart[i] = accum;
+	}
+}
+
+
+
+
+
+uint64_t BitVector1::peekField(size_t readIndex, unsigned length) const
+{
+	uint64_t accum = 0;
+	char *dp = mStart + readIndex;
+	assert(dp+length <= mEnd);
+	for (unsigned i=0; i<length; i++) {
+		accum = (accum<<1) | ((*dp++) & 0x01);
+	}
+	return accum;
+}
+
+
+
+
+uint64_t BitVector1::peekFieldReversed(size_t readIndex, unsigned length) const
+{
+	uint64_t accum = 0;
+	char *dp = mStart + readIndex + length - 1;
+	assert(dp<mEnd);
+	for (int i=(length-1); i>=0; i--) {
+		accum = (accum<<1) | ((*dp--) & 0x01);
+	}
+	return accum;
+}
+
+
+
+
+uint64_t BitVector1::readField(size_t& readIndex, unsigned length) const
+{
+	const uint64_t retVal = peekField(readIndex,length);
+	readIndex += length;
+	return retVal;
+}
+
+
+uint64_t BitVector1::readFieldReversed(size_t& readIndex, unsigned length) const
+{
+	const uint64_t retVal = peekFieldReversed(readIndex,length);
+	readIndex += length;
+	return retVal;
+}
+
+
+
+
+
+void BitVector1::fillField(size_t writeIndex, uint64_t value, unsigned length)
+{
+	char *dpBase = mStart + writeIndex;
+	char *dp = dpBase + length - 1;
+	assert(dp < mEnd);
+	while (dp>=dpBase) {
+		*dp-- = value & 0x01;
+		value >>= 1;
+	}
+}
+
+
+void BitVector1::fillFieldReversed(size_t writeIndex, uint64_t value, unsigned length)
+{
+	char *dp = mStart + writeIndex;
+	char *dpEnd = dp + length - 1;
+	assert(dpEnd < mEnd);
+	while (dp<=dpEnd) {
+		*dp++ = value & 0x01;
+		value >>= 1;
+	}
+}
+
+
+
+
+void BitVector1::writeField(size_t& writeIndex, uint64_t value, unsigned length)
+{
+	fillField(writeIndex,value,length);
+	writeIndex += length;
+}
+
+
+void BitVector1::writeFieldReversed(size_t& writeIndex, uint64_t value, unsigned length)
+{
+	fillFieldReversed(writeIndex,value,length);
+	writeIndex += length;
+}
+
+
+void BitVector1::invert()
+{
+	for (size_t i=0; i<size(); i++) {
+		mStart[i] = ~mStart[i];
+	}
+}
+
+
+
+
+void BitVector1::reverse8()
+{
+	assert(size()>=8);
+
+	char tmp0 = mStart[0];
+	mStart[0] = mStart[7];
+	mStart[7] = tmp0;
+
+	char tmp1 = mStart[1];
+	mStart[1] = mStart[6];
+	mStart[6] = tmp1;
+
+	char tmp2 = mStart[2];
+	mStart[2] = mStart[5];
+	mStart[5] = tmp2;
+
+	char tmp3 = mStart[3];
+	mStart[3] = mStart[4];
+	mStart[4] = tmp3;
+}
+
+
+
+void BitVector1::LSB8MSB()
+{
+	if (size()<8) return;
+	size_t size8 = 8*(size()/8);
+	size_t iTop = size8 - 8;
+	for (size_t i=0; i<=iTop; i+=8) segment(i,8).reverse8();
+}
+
+
+
+uint64_t BitVector1::syndrome(Generator1& gen) const
+{
+	gen.clear();
+	const char *dp = mStart;
+	while (dp<mEnd) gen.syndromeShift(*dp++);
+	return gen.state();
+}
+
+
+uint64_t BitVector1::parity(Generator1 &gen) const
+{
+	gen.clear();
+	const char *dp = mStart;
+	while (dp<mEnd) gen.encoderShift(*dp++);
+	return gen.state();
+}
+
+
+void BitVector1::encode(const ViterbiR2O41& coder, BitVector1& target)
+{
+	size_t sz = size();
+	assert(sz*coder.iRate() == target.size());
+
+	// Build a "history" array where each element contains the full history.
+	uint32_t history[sz];
+	uint32_t accum = 0;
+	for (size_t i=0; i<sz; i++) {
+		accum = (accum<<1) | bit(i);
+		history[i] = accum;
+	}
+
+	// Look up histories in the pre-generated state table.
+	char *op = target.begin();
+	for (size_t i=0; i<sz; i++) {
+		unsigned index = coder.cMask() & history[i];
+		for (unsigned g=0; g<coder.iRate(); g++) {
+			*op++ = coder.stateTable(g,index);
+		}
+	}
+}
+
+
+
+unsigned BitVector1::sum() const
+{
+	unsigned sum = 0;
+	for (size_t i=0; i<size(); i++) sum += mStart[i] & 0x01;
+	return sum;
+}
+
+
+
+
+void BitVector1::map(const unsigned *map, size_t mapSize, BitVector1& dest) const
+{
+	for (unsigned i=0; i<mapSize; i++) {
+		dest.mStart[i] = mStart[map[i]];
+	}
+}
+
+
+
+
+void BitVector1::unmap(const unsigned *map, size_t mapSize, BitVector1& dest) const
+{
+	for (unsigned i=0; i<mapSize; i++) {
+		dest.mStart[map[i]] = mStart[i];
+	}
+}
+
+
+
+
+
+
+
+
+
+
+ostream& operator<<(ostream& os, const BitVector1& hv)
+{
+	for (size_t i=0; i<hv.size(); i++) {
+		if (hv.bit(i)) os << '1';
+		else os << '0';
+	}
+	return os;
+}
+
+
+
+
+ViterbiR2O41::ViterbiR2O41()
+{
+	assert(mDeferral < 32);
+	mCoeffs[0] = 0x019;
+	mCoeffs[1] = 0x01b;
+	computeStateTables(0);
+	computeStateTables(1);
+	computeGeneratorTable();
+}
+
+
+
+
+void ViterbiR2O41::initializeStates()
+{
+	for (unsigned i=0; i<mIStates; i++) clear(mSurvivors[i]);
+	for (unsigned i=0; i<mNumCands; i++) clear(mCandidates[i]);
+}
+
+
+
+void ViterbiR2O41::computeStateTables(unsigned g)
+{
+	assert(g<mIRate);
+	for (unsigned state=0; state<mIStates; state++) {
+		// 0 input
+		uint32_t inputVal = state<<1;
+		mStateTable[g][inputVal] = applyPoly(inputVal, mCoeffs[g], mOrder+1);
+		// 1 input
+		inputVal |= 1;
+		mStateTable[g][inputVal] = applyPoly(inputVal, mCoeffs[g], mOrder+1);
+	}
+}
+
+void ViterbiR2O41::computeGeneratorTable()
+{
+	for (unsigned index=0; index<mIStates*2; index++) {
+		mGeneratorTable[index] = (mStateTable[0][index]<<1) | mStateTable[1][index];
+	}
+}
+
+
+
+
+
+
+void ViterbiR2O41::branchCandidates()
+{
+	// Branch to generate new input states.
+	const vCand *sp = mSurvivors;
+	for (unsigned i=0; i<mNumCands; i+=2) {
+		// extend and suffix
+		const uint32_t iState0 = (sp->iState) << 1;				// input state for 0
+		const uint32_t iState1 = iState0 | 0x01;				// input state for 1
+		const uint32_t oStateShifted = (sp->oState) << mIRate;	// shifted output
+		const float cost = sp->cost;
+		sp++;
+		// 0 input extension
+		mCandidates[i].cost = cost;
+		mCandidates[i].oState = oStateShifted | mGeneratorTable[iState0 & mCMask];
+		mCandidates[i].iState = iState0;
+		// 1 input extension
+		mCandidates[i+1].cost = cost;
+		mCandidates[i+1].oState = oStateShifted | mGeneratorTable[iState1 & mCMask];
+		mCandidates[i+1].iState = iState1;
+	}
+}
+
+
+void ViterbiR2O41::getSoftCostMetrics(const uint32_t inSample, const float *matchCost, const float *mismatchCost)
+{
+	const float *cTab[2] = {matchCost,mismatchCost};
+	for (unsigned i=0; i<mNumCands; i++) {
+		vCand& thisCand = mCandidates[i];
+		// We examine input bits 2 at a time for a rate 1/2 coder.
+		const unsigned mismatched = inSample ^ (thisCand.oState);
+		thisCand.cost += cTab[mismatched&0x01][1] + cTab[(mismatched>>1)&0x01][0];
+	}
+}
+
+
+void ViterbiR2O41::pruneCandidates()
+{
+	const vCand* c1 = mCandidates;					// 0-prefix
+	const vCand* c2 = mCandidates + mIStates;		// 1-prefix
+	for (unsigned i=0; i<mIStates; i++) {
+		if (c1[i].cost < c2[i].cost) mSurvivors[i] = c1[i];
+		else mSurvivors[i] = c2[i];
+	}
+}
+
+
+const ViterbiR2O41::vCand& ViterbiR2O41::minCost() const
+{
+	int minIndex = 0;
+	float minCost = mSurvivors[0].cost;
+	for (unsigned i=1; i<mIStates; i++) {
+		const float thisCost = mSurvivors[i].cost;
+		if (thisCost>=minCost) continue;
+		minCost = thisCost;
+		minIndex=i;
+	}
+	return mSurvivors[minIndex];
+}
+
+
+const ViterbiR2O41::vCand& ViterbiR2O41::step(uint32_t inSample, const float *probs, const float *iprobs)
+{
+	branchCandidates();
+	getSoftCostMetrics(inSample,probs,iprobs);
+	pruneCandidates();
+	return minCost();
+}
+
+
+uint64_t Parity1::syndrome(const BitVector1& receivedCodeword)
+{
+	return receivedCodeword.syndrome(*this);
+}
+
+
+void Parity1::writeParityWord(const BitVector1& data, BitVector1& parityTarget, bool invert)
+{
+	uint64_t pWord = data.parity(*this);
+	if (invert) pWord = ~pWord; 
+	parityTarget.fillField(0,pWord,size());
+}
+
+
+
+
+
+
+
+
+
+SoftVector1::SoftVector1(const BitVector1& source)
+{
+	resize(source.size());
+	for (size_t i=0; i<size(); i++) {
+		if (source.bit(i)) mStart[i]=1.0F;
+		else mStart[i]=0.0F;
+	}
+}
+
+
+BitVector1 SoftVector1::sliced() const
+{
+	size_t sz = size();
+    BitVector1 newSig(sz);
+	for (size_t i=0; i<sz; i++) {
+		if (mStart[i]>0.5F) newSig[i]=1;
+		else newSig[i] = 0;
+	}
+	return newSig;
+}
+
+
+
+void SoftVector1::decode(ViterbiR2O41 &decoder, BitVector1& target) const
+{
+	const size_t sz = size();
+	const unsigned deferral = decoder.deferral();
+	const size_t ctsz = sz + deferral*decoder.iRate();
+	assert(sz <= decoder.iRate()*target.size());
+
+	// Build a "history" array where each element contains the full history.
+	uint32_t history[ctsz];
+	{
+        BitVector1 bits = sliced();
+		uint32_t accum = 0;
+		for (size_t i=0; i<sz; i++) {
+			accum = (accum<<1) | bits.bit(i);
+			history[i] = accum;
+		}
+		// Repeat last bit at the end.
+		for (size_t i=sz; i<ctsz; i++) {
+			accum = (accum<<1) | (accum & 0x01);
+			history[i] = accum;
+		}
+	}
+
+	// Precompute metric tables.
+	float matchCostTable[ctsz];
+	float mismatchCostTable[ctsz];
+	{
+		const float *dp = mStart;
+		for (size_t i=0; i<sz; i++) {
+			// pVal is the probability that a bit is correct.
+			// ipVal is the probability that a bit is incorrect.
+			float pVal = dp[i];
+			if (pVal>0.5F) pVal = 1.0F-pVal;
+			float ipVal = 1.0F-pVal;
+			// This is a cheap approximation to an ideal cost function.
+			if (pVal<0.01F) pVal = 0.01;
+			if (ipVal<0.01F) ipVal = 0.01;
+			matchCostTable[i] = 0.25F/ipVal;
+			mismatchCostTable[i] = 0.25F/pVal;
+		}
+	
+		// pad end of table with unknowns
+		for (size_t i=sz; i<ctsz; i++) {
+			matchCostTable[i] = 0.5F;
+			mismatchCostTable[i] = 0.5F;
+		}
+	}
+
+	{
+		decoder.initializeStates();
+		// Each sample of history[] carries its history.
+		// So we only have to process every iRate-th sample.
+		const unsigned step = decoder.iRate();
+		// input pointer
+		const uint32_t *ip = history + step - 1;
+		// output pointers
+		char *op = target.begin();
+		const char *const opt = target.end();
+		// table pointers
+		const float* match = matchCostTable;
+		const float* mismatch = mismatchCostTable;
+		size_t oCount = 0;
+		while (op<opt) {
+			// Viterbi algorithm
+			assert(match-matchCostTable<sizeof(matchCostTable)/sizeof(matchCostTable[0])-1);
+			assert(mismatch-mismatchCostTable<sizeof(mismatchCostTable)/sizeof(mismatchCostTable[0])-1);
+            const ViterbiR2O41::vCand &minCost = decoder.step(*ip, match, mismatch);
+			ip += step;
+			match += step;
+			mismatch += step;
+			// output
+			if (oCount>=deferral) *op++ = (minCost.iState >> deferral)&0x01;
+			oCount++;
+		}
+	}
+}
+
+
+
+
+ostream& operator<<(ostream& os, const SoftVector1& sv)
+{
+	for (size_t i=0; i<sv.size(); i++) {
+		if (sv[i]<0.25) os << "0";
+		else if (sv[i]>0.75) os << "1";
+		else os << "-";
+	}
+	return os;
+}
+
+
+
+void BitVector1::pack(unsigned char* targ) const
+{
+	// Assumes MSB-first packing.
+	unsigned bytes = size()/8;
+	for (unsigned i=0; i<bytes; i++) {
+		targ[i] = peekField(i*8,8);
+	}
+	unsigned whole = bytes*8;
+	unsigned rem = size() - whole;
+	if (rem==0) return;
+	targ[bytes] = peekField(whole,rem) << (8-rem);
+}
+
+
+void BitVector1::unpack(const unsigned char* src)
+{
+	// Assumes MSB-first packing.
+	unsigned bytes = size()/8;
+	for (unsigned i=0; i<bytes; i++) {
+		fillField(i*8,src[i],8);
+	}
+	unsigned whole = bytes*8;
+	unsigned rem = size() - whole;
+	if (rem==0) return;
+	fillField(whole,src[bytes],rem);
+}
+
+void BitVector1::hex(ostream& os) const
+{
+	os << std::hex;
+	int v=0;
+	unsigned digits = size()/4;
+	size_t wp=0;
+	for (unsigned i=0; i<digits; i++) {
+		os << readField(wp,4);
+	}
+	os << std::dec;
+}
+
+// vim: ts=4 sw=4

--- a/lib/BitVector1.h
+++ b/lib/BitVector1.h
@@ -1,0 +1,437 @@
+/*
+* Copyright 2008, 2009 Free Software Foundation, Inc.
+*
+* This software is distributed under the terms of the GNU Affero Public License.
+* See the COPYING file in the main directory for details.
+*
+* This use of this software may be subject to additional restrictions.
+* See the LEGAL file in the main directory for details.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+
+#ifndef FECVECTORS_H
+#define FECVECTORS_H
+
+#include "Vector1.h"
+#include <stdint.h>
+
+
+class BitVector1;
+class SoftVector1;
+
+
+
+/** Shift-register (LFSR) generator. */
+class Generator1 {
+
+	private:
+
+	uint64_t mCoeff;	///< polynomial coefficients. LSB is zero exponent.
+	uint64_t mState;	///< shift register state. LSB is most recent.
+	uint64_t mMask;		///< mask for reading state
+	unsigned mLen;		///< number of bits used in shift register
+	unsigned mLen_1;	///< mLen - 1
+
+	public:
+
+    Generator1(uint64_t wCoeff, unsigned wLen)
+		:mCoeff(wCoeff),mState(0),
+		mMask((1ULL<<wLen)-1),
+		mLen(wLen),mLen_1(wLen-1)
+	{ assert(wLen<64); }
+
+	void clear() { mState=0; }
+
+	/**@name Accessors */
+	//@{
+	uint64_t state() const { return mState & mMask; }
+	unsigned size() const { return mLen; }
+	//@}
+
+	/**
+		Calculate one bit of a syndrome.
+		This is in the .h for inlining.
+	*/
+	void syndromeShift(unsigned inBit)
+	{
+		const unsigned fb = (mState>>(mLen_1)) & 0x01;
+		mState = (mState<<1) ^ (inBit & 0x01);
+		if (fb) mState ^= mCoeff;
+	}
+
+	/**
+		Update the generator state by one cycle.
+		This is in the .h for inlining.
+	*/
+	void encoderShift(unsigned inBit)
+	{
+		const unsigned fb = ((mState>>(mLen_1)) ^ inBit) & 0x01;
+		mState <<= 1;
+		if (fb) mState ^= mCoeff;
+	}
+
+
+};
+
+
+
+
+/** Parity (CRC-type) generator and checker based on a Generator. */
+class Parity1 : public Generator1 {
+
+	protected:
+
+	unsigned mCodewordSize;
+
+	public:
+
+    Parity1(uint64_t wCoefficients, unsigned wParitySize, unsigned wCodewordSize)
+        :Generator1(wCoefficients, wParitySize),
+		mCodewordSize(wCodewordSize)
+	{ }
+
+	/** Compute the parity word and write it into the target segment.  */
+    void writeParityWord(const BitVector1& data, BitVector1& parityWordTarget, bool invert=true);
+
+	/** Compute the syndrome of a received sequence. */
+    uint64_t syndrome(const BitVector1& receivedCodeword);
+};
+
+
+
+
+/**
+	Class to represent convolutional coders/decoders of rate 1/2, memory length 4.
+	This is the "workhorse" coder for most GSM channels.
+*/
+class ViterbiR2O41 {
+
+	private:
+		/**name Lots of precomputed elements so the compiler can optimize like hell. */
+		//@{
+		/**@name Core values. */
+		//@{
+		static const unsigned mIRate = 2;	///< reciprocal of rate
+		static const unsigned mOrder = 4;	///< memory length of generators
+		//@}
+		/**@name Derived values. */
+		//@{
+		static const unsigned mIStates = 0x01 << mOrder;	///< number of states, number of survivors
+		static const uint32_t mSMask = mIStates-1;			///< survivor mask
+		static const uint32_t mCMask = (mSMask<<1) | 0x01;	///< candidate mask
+		static const uint32_t mOMask = (0x01<<mIRate)-1;	///< ouput mask, all iRate low bits set
+		static const unsigned mNumCands = mIStates*2;		///< number of candidates to generate during branching
+		static const unsigned mDeferral = 6*mOrder;			///< deferral to be used
+		//@}
+		//@}
+
+		/** Precomputed tables. */
+		//@{
+		uint32_t mCoeffs[mIRate];					///< polynomial for each generator
+		uint32_t mStateTable[mIRate][2*mIStates];	///< precomputed generator output tables
+		uint32_t mGeneratorTable[2*mIStates];		///< precomputed coder output table
+		//@}
+	
+	public:
+
+		/**
+		  A candidate sequence in a Viterbi decoder.
+		  The 32-bit state register can support a deferral of 6 with a 4th-order coder.
+		 */
+		typedef struct candStruct {
+			uint32_t iState;	///< encoder input associated with this candidate
+			uint32_t oState;	///< encoder output associated with this candidate
+			float cost;			///< cost (metric value), float to support soft inputs
+		} vCand;
+
+		/** Clear a structure. */
+		void clear(vCand& v)
+		{
+			v.iState=0;
+			v.oState=0;
+			v.cost=0;
+		}
+		
+
+	private:
+
+		/**@name Survivors and candidates. */
+		//@{
+		vCand mSurvivors[mIStates];			///< current survivor pool
+		vCand mCandidates[2*mIStates];		///< current candidate pool
+		//@}
+
+	public:
+
+		unsigned iRate() const { return mIRate; }
+		uint32_t cMask() const { return mCMask; }
+		uint32_t stateTable(unsigned g, unsigned i) const { return mStateTable[g][i]; }
+		unsigned deferral() const { return mDeferral; }
+		
+
+        ViterbiR2O41();
+
+		/** Set all cost metrics to zero. */
+		void initializeStates();
+
+		/**
+			Full cycle of the Viterbi algorithm: branch, metrics, prune, select.
+			@return reference to minimum-cost candidate.
+		*/
+		const vCand& step(uint32_t inSample, const float *probs, const float *iprobs);
+
+	private:
+
+		/** Branch survivors into new candidates. */
+		void branchCandidates();
+
+		/** Compute cost metrics for soft-inputs. */
+		void getSoftCostMetrics(uint32_t inSample, const float *probs, const float *iprobs);
+
+		/** Select survivors from the candidate set. */
+		void pruneCandidates();
+
+		/** Find the minimum cost survivor. */
+		const vCand& minCost() const;
+
+		/**
+			Precompute the state tables.
+			@param g Generator index 0..((1/rate)-1)
+		*/
+		void computeStateTables(unsigned g);
+
+		/**
+			Precompute the generator outputs.
+			mCoeffs must be defined first.
+		*/
+		void computeGeneratorTable();
+
+};
+
+
+
+
+class BitVector1 : public Vector1<char> {
+
+
+	public:
+
+	/**@name Constructors. */
+	//@{
+
+	/**@name Casts of Vector constructors. */
+	//@{
+    BitVector1(char* wData, char* wStart, char* wEnd)
+        :Vector1<char>(wData,wStart,wEnd)
+	{ }
+    BitVector1(size_t len=0):Vector1<char>(len) {}
+    BitVector1(const Vector1<char>& source):Vector1<char>(source) {}
+    BitVector1(Vector1<char>& source):Vector1<char>(source) {}
+    BitVector1(const Vector1<char>& source1, const Vector1<char> source2):Vector1<char>(source1,source2) {}
+	//@}
+
+	/** Construct from a string of "0" and "1". */
+    BitVector1(std::string valString);
+	//@}
+
+	/** Index a single bit. */
+	bool bit(size_t index) const
+	{
+		// We put this code in .h for fast inlining.
+		const char *dp = mStart+index;
+		assert(dp<mEnd);
+		return (*dp) & 0x01;
+	}
+
+	/**@name Casts and overrides of Vector operators. */
+	//@{
+    BitVector1 segment(size_t start, size_t span)
+	{
+		char* wStart = mStart + start;
+		char* wEnd = wStart + span;
+		assert(wEnd<=mEnd);
+        return BitVector1(NULL,wStart,wEnd);
+	}
+
+    BitVector1 alias()
+		{ return segment(0,size()); }
+
+    const BitVector1 segment(size_t start, size_t span) const
+        { return (BitVector1)(Vector1<char>::segment(start,span)); }
+
+    BitVector1 head(size_t span) { return segment(0,span); }
+    const BitVector1 head(size_t span) const { return segment(0,span); }
+    BitVector1 tail(size_t start) { return segment(start,size()-start); }
+    const BitVector1 tail(size_t start) const { return segment(start,size()-start); }
+	//@}
+
+
+	void zero() { fill(0); }
+
+	/**@name FEC operations. */
+	//@{
+	/** Calculate the syndrome of the vector with the given Generator. */
+    uint64_t syndrome(Generator1& gen) const;
+	/** Calculate the parity word for the vector with the given Generator. */
+    uint64_t parity(Generator1& gen) const;
+	/** Encode the signal with the GSM rate 1/2 convolutional encoder. */
+    void encode(const ViterbiR2O41& encoder, BitVector1& target);
+	//@}
+
+
+	/** Invert 0<->1. */
+	void invert();
+
+	/**@name Byte-wise operations. */
+	//@{
+	/** Reverse an 8-bit vector. */
+	void reverse8();
+	/** Reverse groups of 8 within the vector (byte reversal). */
+	void LSB8MSB();
+	//@}
+
+	/**@name Serialization and deserialization. */
+	//@{
+	uint64_t peekField(size_t readIndex, unsigned length) const;
+	uint64_t peekFieldReversed(size_t readIndex, unsigned length) const;
+	uint64_t readField(size_t& readIndex, unsigned length) const;
+	uint64_t readFieldReversed(size_t& readIndex, unsigned length) const;
+	void fillField(size_t writeIndex, uint64_t value, unsigned length);
+	void fillFieldReversed(size_t writeIndex, uint64_t value, unsigned length);
+	void writeField(size_t& writeIndex, uint64_t value, unsigned length);
+	void writeFieldReversed(size_t& writeIndex, uint64_t value, unsigned length);
+	//@}
+
+	/** Sum of bits. */
+	unsigned sum() const;
+
+	/** Reorder bits, dest[i] = this[map[i]]. */
+    void map(const unsigned *map, size_t mapSize, BitVector1& dest) const;
+
+	/** Reorder bits, dest[map[i]] = this[i]. */
+    void unmap(const unsigned *map, size_t mapSize, BitVector1& dest) const;
+
+	/** Pack into a char array. */
+	void pack(unsigned char*) const;
+
+	/** Unopack from a char array. */
+	void unpack(const unsigned char*);
+
+	/** Make a hexdump string. */
+	void hex(std::ostream&) const;
+
+};
+
+
+
+std::ostream& operator<<(std::ostream&, const BitVector1&);
+
+
+
+
+
+
+/**
+  The SoftVector class is used to represent a soft-decision signal.
+  Values 0..1 represent probabilities that a bit is "true".
+ */
+class SoftVector1: public Vector1<float> {
+
+	public:
+
+	/** Build a SoftVector of a given length. */
+    SoftVector1(size_t wSize=0):Vector1<float>(wSize) {}
+
+	/** Construct a SoftVector from a C string of "0", "1", and "X". */
+    SoftVector1(const char* valString);
+
+	/** Construct a SoftVector from a BitVector. */
+    SoftVector1(const BitVector1& source);
+
+	/**
+		Wrap a SoftVector around a block of floats.
+		The block will be delete[]ed upon desctuction.
+	*/
+    SoftVector1(float *wData, unsigned length)
+        :Vector1<float>(wData,length)
+	{}
+
+    SoftVector1(float* wData, float* wStart, float* wEnd)
+        :Vector1<float>(wData,wStart,wEnd)
+	{ }
+
+	/**
+		Casting from a Vector<float>.
+		Note that this is NOT pass-by-reference.
+	*/
+    SoftVector1(Vector1<float> source)
+        :Vector1<float>(source)
+	{}
+
+
+	/**@name Casts and overrides of Vector operators. */
+	//@{
+    SoftVector1 segment(size_t start, size_t span)
+	{
+		float* wStart = mStart + start;
+		float* wEnd = wStart + span;
+		assert(wEnd<=mEnd);
+        return SoftVector1(NULL,wStart,wEnd);
+	}
+
+    SoftVector1 alias()
+		{ return segment(0,size()); }
+
+    const SoftVector1 segment(size_t start, size_t span) const
+        { return (SoftVector1)(Vector1<float>::segment(start,span)); }
+
+    SoftVector1 head(size_t span) { return segment(0,span); }
+    const SoftVector1 head(size_t span) const { return segment(0,span); }
+    SoftVector1 tail(size_t start) { return segment(start,size()-start); }
+    const SoftVector1 tail(size_t start) const { return segment(start,size()-start); }
+	//@}
+
+	/** Decode soft symbols with the GSM rate-1/2 Viterbi decoder. */
+    void decode(ViterbiR2O41 &decoder, BitVector1& target) const;
+
+	/** Fill with "unknown" values. */
+	void unknown() { fill(0.5F); }
+
+	/** Return a hard bit value from a given index by slicing. */
+	bool bit(size_t index) const
+	{
+		const float *dp = mStart+index;
+		assert(dp<mEnd);
+		return (*dp)>0.5F;
+	}
+
+	/** Slice the whole signal into bits. */
+    BitVector1 sliced() const;
+
+};
+
+
+
+std::ostream& operator<<(std::ostream&, const SoftVector1&);
+
+
+
+
+
+
+#endif
+// vim: ts=4 sw=4

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,7 +66,9 @@ list(APPEND grgsm_sources
     qa_utils/message_sink_impl.cc
     decryption/decryption_impl.cc
     msg_to_tag_impl.cc
-)
+    BER_calc_impl.cc
+    GSMFrameCoder.cpp
+    BitVector1.cpp )
 
 
 add_library(grgsm SHARED ${grgsm_sources})

--- a/lib/GSMFrameCoder.cpp
+++ b/lib/GSMFrameCoder.cpp
@@ -1,0 +1,254 @@
+/*
+
+ * Copyright 2008 Free Software Foundation, Inc.
+ * 
+ * This file is part of GSMFrameCoder
+ * 
+ * GSMFrameCoder is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GSMFrameCoder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GSMFrameCoder; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+
+ *
+ *
+ * GSMFrameCoder.cpp
+ *
+ *  Created on: 19.12.2010
+ *      Author: Johann Betz ( jbetz@informatik.uni-freiburg.de )
+ */
+
+#include <fstream>
+
+#include "GSMFrameCoder.h"
+
+//#include "GSMTransfer.h"
+#include <string>
+#include <iostream>
+//#include <stdio.h>
+#include <stdlib.h>
+
+using namespace std;
+
+Parity1 mBlockCoder(0x10004820009ULL, 40, 224); ///< block coder for this channel
+BitVector1 mI[4]; ///< i[][], as per GSM 05.03 2.2
+BitVector1 mC(456); ///< c[], as per GSM 05.03 2.2
+BitVector1 mU(228); ///< u[], as per GSM 05.03 2.2
+BitVector1 mD(mU.head(184)); ///< d[], as per GSM 05.03 2.2
+BitVector1 mP(mU.segment(184, 40)); ///< p[], as per GSM 05.03 2.2*/
+ViterbiR2O41 mVCoder;
+
+void GSMFrameCoder::encode() {
+	// Perform the FEC encoding of GSM 05.03 4.1.2 and 4.1.3
+
+	// GSM 05.03 4.1.2
+	// Generate the parity bits.
+	mBlockCoder.writeParityWord(mD, mP);
+	//OBJLOG(DEEPDEBUG) << "XCCHL1Encoder u[]=" << mU;
+	// GSM 05.03 4.1.3
+	// Apply the convolutional encoder.
+	mU.encode(mVCoder, mC);
+	//OBJLOG(DEEPDEBUG) << "XCCHL1Encoder c[]=" << mC;
+}
+
+void GSMFrameCoder::interleave() {
+	// GSM 05.03, 4.1.4.  Verbatim.
+	for (int k = 0; k < 456; k++) {
+		int B = k % 4;
+		int j = 2 * ((49 * k) % 57) + ((k % 8) / 4);
+		mI[B][j] = mC[k];
+	}
+}
+
+BitVector1* GSMFrameCoder::justencode(const BitVector1 &frame) {
+	frame.copyToSegment(mU, 0);
+	mD.LSB8MSB();
+	encode(); // Encode u[] to c[], GSM 05.03 4.1.2 and 4.1.3.
+	interleave(); // Interleave c[] to i[][], GSM 05.03 4.1.4.
+	return mI;
+}
+
+void strip_spaces(char* string) {
+	char *p1 = string;
+	char *p2 = string;
+	p1 = string;
+	while (*p1 != 0) {
+		if (isspace(*p1)) {
+			++p1;
+		} else
+			*p2++ = *p1++;
+	}
+	*p2 = 0;
+}
+
+string htoi(const char *ptr) {
+	char ch = *ptr;
+	int length = strlen(ptr);
+	string value;
+
+	while (ch == ' ' || ch == '\t')
+		ch = *(++ptr);
+	int i;
+	for (i = 0; i < length; i++) {
+		//const char* bin;
+		string bin;
+		if (!isspace(ch)) {
+			switch (tolower(ch)) {
+			case '0':
+				bin = "0000";
+				break;
+			case '1':
+				bin = "0001";
+				break;
+			case '2':
+				bin = "0010";
+				break;
+			case '3':
+				bin = "0011";
+				break;
+			case '4':
+				bin = "0100";
+				break;
+			case '5':
+				bin = "0101";
+				break;
+			case '6':
+				bin = "0110";
+				break;
+			case '7':
+				bin = "0111";
+				break;
+			case '8':
+				bin = "1000";
+				break;
+			case '9':
+				bin = "1001";
+				break;
+			case 'a':
+				bin = "1010";
+				break;
+			case 'b':
+				bin = "1011";
+				break;
+			case 'c':
+				bin = "1100";
+				break;
+			case 'd':
+				bin = "1101";
+				break;
+			case 'e':
+				bin = "1110";
+				break;
+			case 'f':
+				bin = "1111";
+				break;
+			default:
+				return value.c_str();
+			}
+			value.append(bin);
+		}
+		ch = *(++ptr);
+	}
+    return value;
+}
+
+string GSMFrameCoder::BitInv(char *inbits, int len)
+{
+    string BitInved;
+    for (int aa=0; aa<len/8; aa++)
+    {
+        for (int bb=7; bb>=0; bb--)
+        {
+            if (inbits[bb+aa*8] == 0x00)
+                BitInved.push_back('0');
+            else
+                BitInved.push_back('1');
+        }
+    }
+//    BitInved.append("\0");
+    return BitInved;
+}
+
+BitVector1* GSMFrameCoder::func(int argc, char *argv[]) {
+	bool binary = false;
+	int bpos = 1;
+    BitVector1 framebits;
+    string bits;
+    char* input;
+	input = (char*) malloc(500 * sizeof(int));
+
+	if (argc > 1) {
+		for (int i = 1; i < argc; i++) {
+			if (strcmp(argv[i], "-b") == 0) {
+				binary = true;
+				bpos = 1;
+				if (i < argc - 1) {
+					bpos = i + 1;
+				}
+			} else {
+                strcpy(input, argv[i]);
+
+			}
+		}
+
+		// Set up the interleaving buffers.
+		for (int k = 0; k < 4; k++) {
+            mI[k] = BitVector1(114);
+			// Fill with zeros just to make Valgrind happy.
+			mI[k].fill(0);
+		}
+
+		// zero out u[] to take care of tail fields
+		mU.zero();
+
+		if (!binary) {
+			//todo convert into binary
+            string inbits = htoi(input);
+//            cout << "Decoding bits " << inbits << endl;
+            framebits = BitVector1(inbits.c_str());
+//			cout << "frame bits " << framebits << endl;
+		} else {
+//			cout << "Decoding binary" << endl;
+            bits = BitInv(argv[bpos],184);
+//            cout << "bits going to encode ... \n";
+//            cout << bits << endl;
+//            for (int bb=0; bb<184 ; bb++)
+//            {
+//                if (bits[bb] == 0x00)
+//                    std::cout << '0';
+//                else if (bits[bb] == 0x01)
+//                    std::cout << '1';
+//                else
+//                    std::cout << "else" ;
+//            }
+//            std::cout.flush();
+//            std::cout << std::endl;
+
+            framebits = BitVector1(bits);
+		}
+//        cout << "frame bits \n" << framebits << endl;
+        BitVector1* encframe;
+
+		encframe = justencode(framebits);
+//		cout << "Encoded Frame, Burst1: " << "\n" << encframe[0] << endl;
+//		cout << "Encoded Frame, Burst2: " << "\n" << encframe[1] << endl;
+//		cout << "Encoded Frame, Burst3: " << "\n" << encframe[2] << endl;
+//		cout << "Encoded Frame, Burst4: " << "\n" << encframe[3] << endl;
+
+        return encframe;
+	} else {
+		cout << "Usage:\n" << "gsmframecoder <burst to encode>\n"
+				<< "-b <burst to encode> - give the burst in binary representation instead of hex"
+				<< endl;
+	}
+}
+

--- a/lib/GSMFrameCoder.h
+++ b/lib/GSMFrameCoder.h
@@ -1,0 +1,73 @@
+/*
+
+ * Copyright 2008 Free Software Foundation, Inc.
+ * 
+ * This file is part of GSMFrameCoder
+ * 
+ * GSMFrameCoder is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GSMFrameCoder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GSMFrameCoder; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+
+ *
+ *
+ * GSMFrameCoder.h
+ *
+ *  Created on: 19.12.2010
+ *      Author: Johann Betz ( jbetz@informatik.uni-freiburg.de )
+ */
+
+#ifndef GSMFRAMECODER_H_
+#define GSMFRAMECODER_H_
+
+#include "BitVector1.h"
+
+using namespace std;
+class GSMFrameCoder {
+
+	public:
+
+	/**@name FEC signal processing state.  */
+	/*//@{
+	Parity mBlockCoder;			///< block coder for this channel
+	BitVector mI[4];			///< i[][], as per GSM 05.03 2.2
+	BitVector mC;				///< c[], as per GSM 05.03 2.2
+	BitVector mU;				///< u[], as per GSM 05.03 2.2
+	BitVector mD;				///< d[], as per GSM 05.03 2.2
+	BitVector mP;				///< p[], as per GSM 05.03 2.2
+	//@}*/
+
+
+	/** Offset from the start of mU to the start of the L2 frame. */
+	//virtual unsigned headerOffset() const { return 0; }
+
+	/**
+	  Encode u[] to c[].
+	  Includes LSB-MSB reversal within each octet.
+	*/
+	void encode();
+
+	/**
+	  Interleave c[] to i[].
+	  GSM 05.03 4.1.4.
+	*/
+    void interleave();
+
+	/** Just encode u[] to c[], interleave and return the interleaved bursts as BitVector[] */
+    BitVector1* justencode(const BitVector1&);
+    BitVector1 *func(int argc, char *argv[]);
+    string BitInv(char *inbits, int len);
+
+};
+
+#endif /* GSMFRAMECODER_H_ */

--- a/lib/Vector1.h
+++ b/lib/Vector1.h
@@ -1,0 +1,268 @@
+/**@file Simplified Vector template with aliases. */
+/*
+* Copyright 2008 Free Software Foundation, Inc.
+*
+* This software is distributed under the terms of the GNU Affero Public License.
+* See the COPYING file in the main directory for details.
+*
+* This use of this software may be subject to additional restrictions.
+* See the LEGAL file in the main directory for details.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+
+
+
+#ifndef VECTOR_H
+#define VECTOR_H
+
+#include <string.h>
+#include <iostream>
+#include <assert.h>
+
+
+/**
+	A simplified Vector template with aliases.
+	Unlike std::vector, this class does not support dynamic resizing.
+	Unlike std::vector, this class does support "aliases" and subvectors.
+*/
+template <class T> class Vector1 {
+
+	// TODO -- Replace memcpy calls with for-loops.
+
+	public:
+
+	/**@name Iterator types. */
+	//@{
+	typedef T* iterator;
+	typedef const T* const_iterator;
+	//@}
+
+	protected:
+
+	T* mData;		///< allocated data block, if any
+	T* mStart;		///< start of useful data
+	T* mEnd;		///< end of useful data + 1
+
+	public:
+
+	/** Return the size of the Vector. */
+	size_t size() const
+	{
+		assert(mStart>=mData);
+		assert(mEnd>=mStart);
+		return mEnd - mStart;
+	}
+
+	/** Return size in bytes. */
+	size_t bytes() const { return size()*sizeof(T); }
+
+	/** Change the size of the Vector, discarding content. */
+	void resize(size_t newSize)
+	{
+		if (mData!=NULL) delete[] mData;
+		if (newSize==0) mData=NULL;
+		else mData = new T[newSize];
+		mStart = mData;
+		mEnd = mStart + newSize;
+	}
+
+	/** Release memory and clear pointers. */
+	void clear() { resize(0); }
+
+
+	/** Copy data from another vector. */
+    void clone(const Vector1<T>& other)
+	{
+		resize(other.size());
+		memcpy(mData,other.mStart,other.bytes());
+	}
+
+
+
+
+	//@{
+
+	/** Build an empty Vector of a given size. */
+    Vector1(size_t wSize=0):mData(NULL) { resize(wSize); }
+
+	/** Build a Vector by shifting the data block. */
+    Vector1(Vector1<T>& other)
+		:mData(other.mData),mStart(other.mStart),mEnd(other.mEnd)
+	{ other.mData=NULL; }
+
+	/** Build a Vector by copying another. */
+    Vector1(const Vector1<T>& other):mData(NULL) { clone(other); }
+
+	/** Build a Vector with explicit values. */
+    Vector1(T* wData, T* wStart, T* wEnd)
+		:mData(wData),mStart(wStart),mEnd(wEnd)
+	{ }
+
+	/** Build a vector from an existing block, NOT to be deleted upon destruction. */
+    Vector1(T* wStart, size_t span)
+		:mData(NULL),mStart(wStart),mEnd(wStart+span)
+	{ }
+
+	/** Build a Vector by concatenation. */
+    Vector1(const Vector1<T>& other1, const Vector1<T>& other2)
+		:mData(NULL)
+	{
+		resize(other1.size()+other2.size());
+		memcpy(mStart, other1.mStart, other1.bytes());
+		memcpy(mStart+other1.size(), other2.mStart, other2.bytes());
+	}
+
+	//@}
+
+	/** Destroy a Vector, deleting held memory. */
+    ~Vector1() { clear(); }
+
+
+
+
+	//@{
+
+	/** Assign from another Vector, shifting ownership. */
+    void operator=(Vector1<T>& other)
+	{
+		clear();
+		mData=other.mData;
+		mStart=other.mStart;
+		mEnd=other.mEnd;
+		other.mData=NULL;
+	}
+
+	/** Assign from another Vector, copying. */
+    void operator=(const Vector1<T>& other) { clone(other); }
+
+	//@}
+
+
+	//@{
+
+	/** Return an alias to a segment of this Vector. */
+    Vector1<T> segment(size_t start, size_t span)
+	{
+		T* wStart = mStart + start;
+		T* wEnd = wStart + span;
+		assert(wEnd<=mEnd);
+        return Vector1<T>(NULL,wStart,wEnd);
+	}
+
+	/** Return an alias to a segment of this Vector. */
+    const Vector1<T> segment(size_t start, size_t span) const
+	{
+		T* wStart = mStart + start;
+		T* wEnd = wStart + span;
+		assert(wEnd<=mEnd);
+        return Vector1<T>(NULL,wStart,wEnd);
+	}
+
+    Vector1<T> head(size_t span) { return segment(0,span); }
+    const Vector1<T> head(size_t span) const { return segment(0,span); }
+    Vector1<T> tail(size_t start) { return segment(start,size()-start); }
+    const Vector1<T> tail(size_t start) const { return segment(start,size()-start); }
+
+	/**
+		Copy part of this Vector to a segment of another Vector.
+		@param other The other vector.
+		@param start The start point in the other vector.
+		@param span The number of elements to copy.
+	*/
+    void copyToSegment(Vector1<T>& other, size_t start, size_t span) const
+	{
+		T* base = other.mStart + start;
+		assert(base+span<=other.mEnd);
+		assert(mStart+span<=mEnd);
+		memcpy(base,mStart,span*sizeof(T));
+	}
+
+	/** Copy all of this Vector to a segment of another Vector. */
+    void copyToSegment(Vector1<T>& other, size_t start=0) const { copyToSegment(other,start,size()); }
+
+    void copyTo(Vector1<T>& other) const { copyToSegment(other,0,size()); }
+
+	/**
+		Copy a segment of this vector into another.
+		@param other The other vector (to copt into starting at 0.)
+		@param start The start point in this vector.
+		@param span The number of elements to copy.
+	*/
+    void segmentCopyTo(Vector1<T>& other, size_t start, size_t span) const
+	{
+		const T* base = mStart + start;
+		assert(base+span<=mEnd);
+		assert(other.mStart+span<=other.mEnd);
+		memcpy(other.mStart,base,span*sizeof(T));
+	}
+
+	void fill(const T& val)
+	{
+		T* dp=mStart;
+		while (dp<mEnd) *dp++=val;
+	}
+
+	void fill(const T& val, unsigned start, unsigned length)
+	{
+		T* dp=mStart+start;
+		T* end=dp+length;
+		assert(end<=mEnd);
+		while (dp<end) *dp++=val;
+	}
+
+
+	//@}
+
+
+	//@{
+
+	T& operator[](size_t index)
+	{
+		assert(mStart+index<mEnd);
+		return mStart[index];
+	}
+
+	const T& operator[](size_t index) const
+	{
+		assert(mStart+index<mEnd);
+		return mStart[index];
+	}
+
+	const T* begin() const { return mStart; }
+	T* begin() { return mStart; }
+	const T* end() const { return mEnd; }
+	T* end() { return mEnd; }
+	//@}
+	
+
+};
+
+
+
+
+/** Basic print operator for Vector objects. */
+template <class T>
+std::ostream& operator<<(std::ostream& os, const Vector1<T>& v)
+{
+	for (unsigned i=0; i<v.size(); i++) os << v[i] << " ";
+	return os;
+}
+
+
+
+#endif
+// vim: ts=4 sw=4

--- a/swig/grgsm_swig.i
+++ b/swig/grgsm_swig.i
@@ -38,6 +38,7 @@
 #include "grgsm/misc_utils/message_file_sink.h"
 #include "grgsm/misc_utils/message_file_source.h"
 #include "grgsm/msg_to_tag.h"
+#include "grgsm/BER_calc.h"
 %}
 
 %include "grgsm/receiver/receiver.h"
@@ -106,3 +107,5 @@ GR_SWIG_BLOCK_MAGIC2(gsm, message_source);
 GR_SWIG_BLOCK_MAGIC2(gsm, message_sink);
 %include "grgsm/msg_to_tag.h"
 GR_SWIG_BLOCK_MAGIC2(grgsm, msg_to_tag);
+%include "grgsm/BER_calc.h"
+GR_SWIG_BLOCK_MAGIC2(grgsm, BER_calc);


### PR DESCRIPTION
```
modified:   grc/decoding/gsm_control_channels_decoder.xml
new file:   grc/grgsm_BER_calc.xml
new file:   include/grgsm/BER_calc.h
modified:   include/grgsm/CMakeLists.txt
new file:   lib/BER_calc_impl.cc
new file:   lib/BER_calc_impl.h
new file:   lib/BitVector1.cpp
new file:   lib/BitVector1.h
modified:   lib/CMakeLists.txt
new file:   lib/GSMFrameCoder.cpp
new file:   lib/GSMFrameCoder.h
new file:   lib/Vector1.h
modified:   lib/decoding/control_channels_decoder_impl.cc
modified:   swig/grgsm_swig.i
```

The BER calculator does the following:
1) The correct parity-checked-decoded packets of the control channels are encoded again
2) Compared with the demapped bits of the corresponding packets and BER is calculated.

The decoded and demapped bits of a control channel packet is sent to BER_calc block. Encoding and comparing bits are carried out in BER_calc block.

Hence, if one wants to calculate the received stream BER, needs to connect "de" message ports of "control_channels_decoder" and "BER_calc" blocks and connects output port of BER_calc to a sink block such as "Qt GUI number sink" block.

Hint: The BER_calc block calculates BER for the entire received streams as an average.
