### PR TITLE
Implemented system info collection block

### DIFF
--- a/grc/gsm_block_tree.xml
+++ b/grc/gsm_block_tree.xml
@@ -54,6 +54,7 @@
       <block>gsm_bursts_printer</block>
       <block>gsm_burst_file_sink</block>
       <block>gsm_burst_file_source</block>
+      <block>gsm_collect_system_info</block>
       <block>gsm_message_file_sink</block>
       <block>gsm_message_file_source</block>
       <block>gsm_extract_system_info</block>

--- a/grc/misc_utils/CMakeLists.txt
+++ b/grc/misc_utils/CMakeLists.txt
@@ -20,6 +20,7 @@
 install(FILES
     gsm_extract_system_info.xml
     gsm_extract_immediate_assignment.xml
+    gsm_collect_system_info.xml
     gsm_controlled_rotator_cc.xml
     gsm_message_printer.xml
     gsm_bursts_printer.xml

--- a/grc/misc_utils/gsm_collect_system_info.xml
+++ b/grc/misc_utils/gsm_collect_system_info.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<block>
+  <name>Collect System Info</name>
+  <key>gsm_collect_system_info</key>
+  <import>import grgsm</import>
+  <make>grgsm.collect_system_info()</make>
+  <sink>
+    <name>msgs</name>
+    <type>message</type>
+  </sink>
+    <doc>
+This blocks collect System Information Messages, which can be retrieved using the following methods:
+
+get_framenumbers(): Get the list with the framenumbers of the System Information Messages
+
+get_system_information_type(): Get the types of the System Information Messages
+
+get_data(): Get the whole System Information Messages in Hex representation
+  </doc>
+</block>

--- a/include/grgsm/misc_utils/CMakeLists.txt
+++ b/include/grgsm/misc_utils/CMakeLists.txt
@@ -24,6 +24,7 @@ install(FILES
     bursts_printer.h
     burst_file_source.h
     burst_file_sink.h
+    collect_system_info.h
     message_file_sink.h
     message_file_source.h
     extract_system_info.h

--- a/include/grgsm/misc_utils/collect_system_info.h
+++ b/include/grgsm/misc_utils/collect_system_info.h
@@ -1,0 +1,60 @@
+/* -*- c++ -*- */
+/*
+ * @file
+ * @author Roman Khassraf <rkhassraf@gmail.com>
+ * @section LICENSE
+ *
+ * Gr-gsm is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gr-gsm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gr-gsm; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_GSM_COLLECT_SYSTEM_INFO_H
+#define INCLUDED_GSM_COLLECT_SYSTEM_INFO_H
+
+#include <grgsm/api.h>
+#include <gnuradio/block.h>
+#include <vector>
+
+namespace gr {
+  namespace gsm {
+
+    /*!
+     * \brief <+description of block+>
+     * \ingroup gsm
+     *
+     */
+    class GRGSM_API collect_system_info : virtual public gr::block
+    {
+     public:
+      typedef boost::shared_ptr<collect_system_info> sptr;
+
+      /*!
+       * \brief Return a shared_ptr to a new instance of gsm::collect_system_info.
+       *
+       * To avoid accidental use of raw pointers, gsm::collect_system_info's
+       * constructor is in a private implementation
+       * class. gsm::collect_system_info::make is the public interface for
+       * creating new instances.
+       */
+      static sptr make();
+      virtual std::vector<int> get_framenumbers() = 0;
+      virtual std::vector<std::string> get_system_information_type() = 0;
+      virtual std::vector<std::string> get_data() = 0;
+    };
+  } // namespace gsm
+} // namespace gr
+
+#endif /* INCLUDED_GSM_COLLECT_SYSTEM_INFO_H */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -50,6 +50,7 @@ list(APPEND grgsm_sources
     flow_control/burst_fnr_filter_impl.cc
     flow_control/dummy_burst_filter_impl.cc
     flow_control/uplink_downlink_splitter_impl.cc
+    misc_utils/collect_system_info_impl.cc
     misc_utils/controlled_rotator_cc_impl.cc
     misc_utils/controlled_fractional_resampler_cc_impl.cc
     misc_utils/msg_to_tag_impl.cc

--- a/lib/misc_utils/collect_system_info_impl.cc
+++ b/lib/misc_utils/collect_system_info_impl.cc
@@ -1,0 +1,185 @@
+/* -*- c++ -*- */
+/*
+ * @file
+ * @author Roman Khassraf <rkhassraf@gmail.com>
+ * @section LICENSE
+ *
+ * Gr-gsm is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gr-gsm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gr-gsm; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include <grgsm/gsmtap.h>
+#include <unistd.h>
+#include <grgsm/endian.h>
+
+#include "collect_system_info_impl.h"
+
+namespace gr {
+  namespace gsm {
+    
+    void collect_system_info_impl::process_messages(pmt::pmt_t msg){
+        pmt::pmt_t message_plus_header_blob = pmt::cdr(msg);
+        uint8_t * message_plus_header = (uint8_t *)pmt::blob_data(message_plus_header_blob);
+        gsmtap_hdr * header = (gsmtap_hdr *)message_plus_header;
+        uint8_t * msg_elements = (uint8_t *)(message_plus_header+sizeof(gsmtap_hdr));
+        
+        uint8_t chan_type = header->sub_type;
+                
+        if (chan_type == GSMTAP_CHANNEL_BCCH && msg_elements[1] == 0x06) 
+        {
+            int frame_nr = be32toh(header->frame_number);
+                        
+            if (msg_elements[2]  == 0x19)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 1");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+            else if (msg_elements[2]  == 0x1a)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 2");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+            else if (msg_elements[2]  == 0x1b)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 3");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+            else if (msg_elements[2]  == 0x1c)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 4");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+            else if (msg_elements[2]  == 0x02)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 2bis");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+            else if (msg_elements[2]  == 0x03)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 2ter");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+            else if (msg_elements[2]  == 0x07)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 2quater");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+            else if (msg_elements[2]  == 0x00)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 13");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+        }
+        else if ((chan_type == GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_SDCCH
+            || chan_type == GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_SDCCH4
+            || chan_type == GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_SDCCH8
+            || chan_type == GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_TCH_F
+            || chan_type == GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_TCH_H)
+            && msg_elements[5] == 0x06)
+        {
+            int frame_nr = be32toh(header->frame_number);
+                        
+            if (msg_elements[6]  == 0x1D)
+            {   
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 5");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+            else if (msg_elements[6]  == 0x1E)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 6");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+            else if (msg_elements[6]  == 0x05)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 5bis");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+            else if (msg_elements[6]  == 0x06)
+            {
+                d_framenumbers.push_back(frame_nr);
+                d_sit_types.push_back("System Information Type 5ter");
+                d_sit_data.push_back(get_hex_string(msg_elements));
+            }
+        }
+    }
+    
+    std::vector<int> collect_system_info_impl::get_framenumbers()
+    {
+        return d_framenumbers;
+    }
+    
+    std::vector<std::string> collect_system_info_impl::get_system_information_type()
+    {
+        return d_sit_types;
+    }
+    
+    std::vector<std::string> collect_system_info_impl::get_data()
+    {
+        return d_sit_data;
+    }
+    
+    std::string collect_system_info_impl::get_hex_string(uint8_t * msg_elements)
+    {
+        std::stringstream sstream;
+        for (int i=0; i<23; i++)
+        {
+            sstream << std::setfill ('0') << std::setw(2) << std::hex << static_cast<int>(msg_elements[i]);
+        }
+        return sstream.str();
+    }
+    
+    collect_system_info::sptr
+    collect_system_info::make()
+    {
+      return gnuradio::get_initial_sptr
+        (new collect_system_info_impl());
+    }
+
+    /*
+     * The private constructor
+     */
+    collect_system_info_impl::collect_system_info_impl()
+      : gr::block("collect_system_info",
+              gr::io_signature::make(0, 0, 0),
+              gr::io_signature::make(0, 0, 0))
+    {
+        message_port_register_in(pmt::mp("msgs"));
+        set_msg_handler(pmt::mp("msgs"), boost::bind(&collect_system_info_impl::process_messages, this, _1));
+    }
+    
+    /*
+     * Our virtual destructor.
+     */
+    collect_system_info_impl::~collect_system_info_impl()
+    {
+    }
+  } /* namespace gsm */
+} /* namespace gr */

--- a/lib/misc_utils/collect_system_info_impl.h
+++ b/lib/misc_utils/collect_system_info_impl.h
@@ -1,0 +1,49 @@
+/* -*- c++ -*- */
+/*
+ * @file
+ * @author Roman Khassraf <rkhassraf@gmail.com>
+ * @section LICENSE
+ *
+ * Gr-gsm is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gr-gsm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gr-gsm; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_GSM_COLLECT_SYSTEM_INFO_IMPL_H
+#define INCLUDED_GSM_COLLECT_SYSTEM_INFO_IMPL_H
+
+#include <grgsm/misc_utils/collect_system_info.h>
+#include <vector>
+
+namespace gr {
+  namespace gsm {
+    class collect_system_info_impl : public collect_system_info
+    {
+     private:
+      void process_messages(pmt::pmt_t msg);
+      std::vector<int> d_framenumbers;
+      std::vector<std::string> d_sit_types;
+      std::vector<std::string> d_sit_data;
+      std::string get_hex_string(uint8_t * msg_elements);
+     public:
+      virtual std::vector<int> get_framenumbers();
+      virtual std::vector<std::string> get_system_information_type();
+      virtual std::vector<std::string> get_data();
+      collect_system_info_impl();
+      ~collect_system_info_impl();
+    };
+  } // namespace gsm
+} // namespace gr
+
+#endif /* INCLUDED_GSM_COLLECT_SYSTEM_INFO_IMPL_H */

--- a/swig/grgsm_swig.i
+++ b/swig/grgsm_swig.i
@@ -31,6 +31,7 @@
 #include "grgsm/misc_utils/tmsi_dumper.h"
 #include "grgsm/misc_utils/burst_file_sink.h"
 #include "grgsm/misc_utils/burst_file_source.h"
+#include "grgsm/misc_utils/collect_system_info.h"
 #include "grgsm/qa_utils/burst_sink.h"
 #include "grgsm/qa_utils/burst_source.h"
 #include "grgsm/qa_utils/message_source.h"
@@ -83,6 +84,8 @@ GR_SWIG_BLOCK_MAGIC2(gsm, bursts_printer);
 GR_SWIG_BLOCK_MAGIC2(gsm, burst_file_sink);
 %include "grgsm/misc_utils/burst_file_source.h"
 GR_SWIG_BLOCK_MAGIC2(gsm, burst_file_source);
+%include "grgsm/misc_utils/collect_system_info.h"
+GR_SWIG_BLOCK_MAGIC2(gsm, collect_system_info);
 %include "grgsm/misc_utils/extract_system_info.h"
 GR_SWIG_BLOCK_MAGIC2(gsm, extract_system_info);
 %include "grgsm/misc_utils/extract_immediate_assignment.h"


### PR DESCRIPTION
Hi @ptrkrysik, 

here is another block I created to satisfy some need that emerged during some work.
It's an utility block that takes messages as input and collects all system information messages of SDCCH and SACCH. Unlike the system information extractor, this block collects the whole SI message in HEX representation together with the framenumber and the type of the SI message. 
This block allows processing and interpreting the messages in more details, for example in a workflow / python script.

I didn't open an issue about that, just offering the pr straight forward, hope that is ok for your. 

br, 
Roman