### PR TITLE
Fix the wideband input adaptor (redux)

### DIFF
--- a/grc/receiver/gsm_wideband_input.xml
+++ b/grc/receiver/gsm_wideband_input.xml
@@ -1,3 +1,4 @@
+
 <block>
   <name>GSM Wideband Input Adaptor</name>
   <key>gsm_wideband_input</key>
@@ -104,7 +105,7 @@
     <vlen>1</vlen>
   </sink>
   <sink>
-    <name>ppm_in</name>
+    <name>ctrl_in</name>
     <type>message</type>
     <optional>True</optional>
   </sink>

--- a/python/receiver/gsm_wideband_input.py
+++ b/python/receiver/gsm_wideband_input.py
@@ -22,6 +22,7 @@ class gsm_wideband_input(grgsm.hier_block):
             gr.io_signature(1, 1, gr.sizeof_gr_complex*1),
             gr.io_signature(self.num_streams, self.num_streams, gr.sizeof_gr_complex*1),
         )
+        self.message_port_register_hier_in("ctrl_in")
 
         ##################################################
         # Parameters
@@ -33,34 +34,24 @@ class gsm_wideband_input(grgsm.hier_block):
         self.ca = ca
         self.blocks_fir_filters = {}
         self.blocks_resamplers = {}
-        self.blocks_ocs = {}
+        self.blocks_correctors = {}
         self.band = band
 
         ##################################################
         # Variables
         ##################################################
-        self.samp_rate_out = samp_rate_out = 1625000.0/6.0*osr
+        self.gsm_symb_rate = gsm_symb_rate = 1625000.0/6.0
+        self.samp_rate_out = samp_rate_out = gsm_symb_rate*osr
 
         ##################################################
         # Blocks
         ##################################################
-        self.ppm_in = None
-        self.message_port_register_hier_in("ppm_in")
-        #self.lpf = firdes.low_pass(1, samp_rate_out, 125e3, 5e3, firdes.WIN_HAMMING, 6.76)
-        self.lpf = firdes.low_pass(1, samp_rate_in, 125e3, 75e3, firdes.WIN_HAMMING, 6.76)
-        self.gsm_clock_offset_corrector_0 = grgsm.clock_offset_corrector(
-            fc=fc,
-            ppm=ppm,
-            samp_rate_in=samp_rate_in,
-        )
-
         center_arfcn = arfcn.downlink2arfcn(fc, band)
         fc_str = eng_notation.num_to_str(fc)
         print("Extracting channels %s, given center frequency at %sHz (ARFCN %d)" % (str(ca), fc_str, center_arfcn))
 
-        self.connect((self, 0), (self.gsm_clock_offset_corrector_0, 0))
-
         output_port = 0
+        self.lpf = firdes.low_pass(1, samp_rate_in, 125e3, 5e3, firdes.WIN_HAMMING, 6.76)
         for channel in ca:
             channel_freq = arfcn.arfcn2downlink(channel, band)
             if channel_freq is None:
@@ -71,52 +62,58 @@ class gsm_wideband_input(grgsm.hier_block):
             freq_diff_str += eng_notation.num_to_str(freq_diff)
             print("ARFCN %d is at %sHz %sHz" % (channel, fc_str, freq_diff_str))
 
-            self.blocks_resamplers[channel] = filter.fractional_resampler_cc(0, samp_rate_in/samp_rate_out)
             self.blocks_fir_filters[channel] = filter.freq_xlating_fir_filter_ccc(1, self.lpf, freq_diff, samp_rate_in)
-            self.connect((self.gsm_clock_offset_corrector_0, 0), (self.blocks_fir_filters[channel], 0))
-            self.connect((self.blocks_fir_filters[channel], 0), (self.blocks_resamplers[channel], 0))
-            self.connect((self.blocks_resamplers[channel], 0), (self, output_port))
-            output_port += 1
+            self.blocks_resamplers[channel] = filter.fractional_resampler_cc(0, samp_rate_in/samp_rate_out)
+            self.blocks_correctors[channel] = grgsm.clock_offset_corrector_tagged(
+                fc=fc-freq_diff,
+                samp_rate_in=samp_rate_out,
+                ppm=ppm,
+                osr=osr
+            )
 
-        ##################################################
-        # Asynch Message Connections
-        ##################################################
-        self.msg_connect(self, "ppm_in", self.gsm_clock_offset_corrector_0, "ppm_in")
+            self.connect((self, 0), (self.blocks_fir_filters[channel], 0))
+            self.connect((self.blocks_fir_filters[channel], 0), (self.blocks_resamplers[channel], 0))           
+            self.connect((self.blocks_resamplers[channel], 0), (self.blocks_correctors[channel], 0))
+            self.connect((self.blocks_correctors[channel], 0), (self, output_port))
+            self.msg_connect((self, "ctrl_in"), (self.blocks_correctors[channel], "ctrl"))
+            output_port += 1
 
     def get_ppm(self):
         return self.ppm
 
     def set_ppm(self, ppm):
         self.ppm = ppm
-        self.gsm_clock_offset_corrector_0.set_ppm(self.ppm)
+        for channel in self.ca:
+            self.blocks_correctors[channel].set_ppm(self.ppm)
 
     def get_fc(self):
         return self.fc
 
     def set_fc(self, fc):
         self.fc = fc
-        self.gsm_clock_offset_corrector_0.set_fc(self.fc)
+        for channel in self.ca:
+            self.blocks_correctors[channel].set_fc(self.fc)
 
     def get_osr(self):
         return self.osr
 
     def set_osr(self, osr):
         self.osr = osr
-        self.set_samp_rate_out(1625000.0/6.0*self.osr)
+        self.set_samp_rate_out(self.gsm_symb_rate*self.osr)
 
     def get_samp_rate_in(self):
         return self.samp_rate_in
 
     def set_samp_rate_in(self, samp_rate_in):
         self.samp_rate_in = samp_rate_in
-        for channel in self.blocks_resamplers:
+        for channel in self.ca:
             self.blocks_resamplers[channel].set_resamp_ratio(self.samp_rate_in / self.samp_rate_out)
-        self.gsm_clock_offset_corrector_0.set_samp_rate_in(self.samp_rate_in)
 
     def get_samp_rate_out(self):
         return self.samp_rate_out
 
     def set_samp_rate_out(self, samp_rate_out):
         self.samp_rate_out = samp_rate_out
-        for channel in self.blocks_resamplers:
+        for channel in self.ca:
             self.blocks_resamplers[channel].set_resamp_ratio(self.samp_rate_in / self.samp_rate_out)
+            self.blocks_correctors[channel].set_samp_rate_out(self.samp_rate_out)


### PR DESCRIPTION
Hi Piotr,

I've finally sorted out my changes to the wideband input adaptor. I've moved the clock offset corrector to after the frequency translation and resampling. There are several problems with this:
* the user must specify the _output_ sample rate (symb rate * osr) in the clock offset controller and I think that this is potentially confusing because it's the opposite to the narrowband case,
* it is possibly inefficient - the frequency xlating filter already has a rotator/resampler combination and the corrector adds another rotator/resampler pair. Its possible that refactoring the block's internals would make things run more quickly.

In any case these changes fix the immediate problems.
ATB
Steve