### PR TITLE
External GET/SET API for flow_control blocks

### DIFF
--- a/include/grgsm/flow_control/CMakeLists.txt
+++ b/include/grgsm/flow_control/CMakeLists.txt
@@ -21,6 +21,7 @@
 # Install public header files
 ########################################################################
 install(FILES
+    common.h
     burst_timeslot_splitter.h
     burst_sdcch_subslot_splitter.h
     burst_timeslot_filter.h

--- a/include/grgsm/flow_control/burst_fnr_filter.h
+++ b/include/grgsm/flow_control/burst_fnr_filter.h
@@ -26,6 +26,7 @@
 
 #include <grgsm/api.h>
 #include <gnuradio/block.h>
+#include <grgsm/flow_control/common.h>
 
 namespace gr {
   namespace gsm {
@@ -62,6 +63,10 @@ namespace gr {
 
       virtual filter_mode get_mode(void) = 0;
       virtual filter_mode set_mode(filter_mode mode) = 0;
+
+      /* Filtering policy */
+      virtual filter_policy get_policy(void) = 0;
+      virtual filter_policy set_policy(filter_policy policy) = 0;
     };
 
   } // namespace gsm

--- a/include/grgsm/flow_control/burst_fnr_filter.h
+++ b/include/grgsm/flow_control/burst_fnr_filter.h
@@ -56,6 +56,12 @@ namespace gr {
        */
       static sptr make(filter_mode mode, unsigned int fnr);
 
+      /* External API */
+      virtual unsigned int get_fn(void) = 0;
+      virtual unsigned int set_fn(unsigned int fn) = 0;
+
+      virtual filter_mode get_mode(void) = 0;
+      virtual filter_mode set_mode(filter_mode mode) = 0;
     };
 
   } // namespace gsm

--- a/include/grgsm/flow_control/burst_sdcch_subslot_filter.h
+++ b/include/grgsm/flow_control/burst_sdcch_subslot_filter.h
@@ -54,6 +54,13 @@ namespace gr {
        * creating new instances.
        */
       static sptr make(subslot_filter_mode mode, unsigned int subslot);
+
+      /* External API */
+      virtual unsigned int get_ss(void) = 0;
+      virtual unsigned int set_ss(unsigned int ss) = 0;
+
+      virtual subslot_filter_mode get_mode(void) = 0;
+      virtual subslot_filter_mode set_mode(subslot_filter_mode mode) = 0;
     };
   } // namespace gsm
 } // namespace gr

--- a/include/grgsm/flow_control/burst_sdcch_subslot_filter.h
+++ b/include/grgsm/flow_control/burst_sdcch_subslot_filter.h
@@ -25,6 +25,7 @@
 
 #include <grgsm/api.h>
 #include <gnuradio/block.h>
+#include <grgsm/flow_control/common.h>
 
 namespace gr {
   namespace gsm {
@@ -61,6 +62,10 @@ namespace gr {
 
       virtual subslot_filter_mode get_mode(void) = 0;
       virtual subslot_filter_mode set_mode(subslot_filter_mode mode) = 0;
+
+      /* Filtering policy */
+      virtual filter_policy get_policy(void) = 0;
+      virtual filter_policy set_policy(filter_policy policy) = 0;
     };
   } // namespace gsm
 } // namespace gr

--- a/include/grgsm/flow_control/burst_sdcch_subslot_splitter.h
+++ b/include/grgsm/flow_control/burst_sdcch_subslot_splitter.h
@@ -54,6 +54,10 @@ namespace gr {
        * creating new instances.
        */
       static sptr make(splitter_mode mode);
+
+      /* External API */
+      virtual splitter_mode get_mode(void) = 0;
+      virtual splitter_mode set_mode(splitter_mode mode) = 0;
     };
   } // namespace gsm
 } // namespace gr

--- a/include/grgsm/flow_control/burst_timeslot_filter.h
+++ b/include/grgsm/flow_control/burst_timeslot_filter.h
@@ -48,6 +48,10 @@ namespace gr {
        * creating new instances.
        */
       static sptr make(unsigned int timeslot);
+
+      /* External API */
+      virtual unsigned int get_tn(void) = 0;
+      virtual unsigned int set_tn(unsigned int tn) = 0;
     };
   } // namespace gsm
 } // namespace gr

--- a/include/grgsm/flow_control/burst_timeslot_filter.h
+++ b/include/grgsm/flow_control/burst_timeslot_filter.h
@@ -25,6 +25,7 @@
 
 #include <grgsm/api.h>
 #include <gnuradio/block.h>
+#include <grgsm/flow_control/common.h>
 
 namespace gr {
   namespace gsm {
@@ -52,6 +53,10 @@ namespace gr {
       /* External API */
       virtual unsigned int get_tn(void) = 0;
       virtual unsigned int set_tn(unsigned int tn) = 0;
+
+      /* Filtering policy */
+      virtual filter_policy get_policy(void) = 0;
+      virtual filter_policy set_policy(filter_policy policy) = 0;
     };
   } // namespace gsm
 } // namespace gr

--- a/include/grgsm/flow_control/common.h
+++ b/include/grgsm/flow_control/common.h
@@ -1,0 +1,38 @@
+/* -*- c++ -*- */
+/*
+ * @file
+ * @author Vadim Yanitskiy <axilirator@gmail.com>
+ * @section LICENSE
+ *
+ * Gr-gsm is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gr-gsm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gr-gsm; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_GSM_FLOW_CONTROL_COMMON_H
+#define INCLUDED_GSM_FLOW_CONTROL_COMMON_H
+
+namespace gr {
+  namespace gsm {
+
+    enum filter_policy {
+      FILTER_POLICY_DEFAULT,
+      FILTER_POLICY_PASS_ALL,
+      FILTER_POLICY_DROP_ALL,
+    };
+
+  } /* namespace gsm */
+} /* namespace gr */
+
+#endif

--- a/include/grgsm/flow_control/dummy_burst_filter.h
+++ b/include/grgsm/flow_control/dummy_burst_filter.h
@@ -25,6 +25,7 @@
 
 #include <grgsm/api.h>
 #include <gnuradio/block.h>
+#include <grgsm/flow_control/common.h>
 
 namespace gr {
   namespace gsm {
@@ -48,6 +49,11 @@ namespace gr {
        * creating new instances.
        */
       static sptr make();
+
+      /* External API */
+      /* Filtering policy */
+      virtual filter_policy get_policy(void) = 0;
+      virtual filter_policy set_policy(filter_policy policy) = 0;
     };
   } // namespace gsm
 } // namespace gr

--- a/lib/flow_control/burst_fnr_filter_impl.cc
+++ b/lib/flow_control/burst_fnr_filter_impl.cc
@@ -49,7 +49,8 @@ namespace gr {
               gr::io_signature::make(0, 0, 0),
               gr::io_signature::make(0, 0, 0)),
       d_mode(mode),
-      d_framenr(fnr)
+      d_framenr(fnr),
+      d_filter_policy(FILTER_POLICY_DEFAULT)
     {
         message_port_register_in(pmt::mp("in"));       
         message_port_register_out(pmt::mp("out"));
@@ -64,6 +65,14 @@ namespace gr {
 
     void burst_fnr_filter_impl::process_burst(pmt::pmt_t msg)
     {
+        if (d_filter_policy == FILTER_POLICY_DROP_ALL)
+          return;
+
+        if (d_filter_policy == FILTER_POLICY_PASS_ALL) {
+          message_port_pub(pmt::mp("out"), msg);
+          return;
+        }
+
         pmt::pmt_t header_plus_burst = pmt::cdr(msg);
         gsmtap_hdr * header = (gsmtap_hdr *)pmt::blob_data(header_plus_burst);
         
@@ -104,6 +113,20 @@ namespace gr {
     {
       d_mode = mode;
       return d_mode;
+    }
+
+    /* Filtering policy */
+    filter_policy
+    burst_fnr_filter_impl::get_policy(void)
+    {
+      return d_filter_policy;
+    }
+
+    filter_policy
+    burst_fnr_filter_impl::set_policy(filter_policy policy)
+    {
+      d_filter_policy = policy;
+      return d_filter_policy;
     }
 
   } /* namespace gsm */

--- a/lib/flow_control/burst_fnr_filter_impl.cc
+++ b/lib/flow_control/burst_fnr_filter_impl.cc
@@ -75,5 +75,36 @@ namespace gr {
             message_port_pub(pmt::mp("out"), msg);
         }
     }
+
+    /* External API */
+    unsigned int
+    burst_fnr_filter_impl::get_fn(void)
+    {
+      return d_framenr;
+    }
+
+    unsigned int
+    burst_fnr_filter_impl::set_fn(unsigned int fn)
+    {
+      if (fn <= GSM_HYPERFRAME)
+        d_framenr = fn;
+
+      return d_framenr;
+    }
+
+
+    filter_mode
+    burst_fnr_filter_impl::get_mode(void)
+    {
+      return d_mode;
+    }
+
+    filter_mode
+    burst_fnr_filter_impl::set_mode(filter_mode mode)
+    {
+      d_mode = mode;
+      return d_mode;
+    }
+
   } /* namespace gsm */
 } /* namespace gr */

--- a/lib/flow_control/burst_fnr_filter_impl.h
+++ b/lib/flow_control/burst_fnr_filter_impl.h
@@ -25,6 +25,9 @@
 
 #include <grgsm/flow_control/burst_fnr_filter.h>
 
+#define GSM_SUPERFRAME    (26 * 51)
+#define GSM_HYPERFRAME    (2048 * GSM_SUPERFRAME)
+
 namespace gr {
   namespace gsm {
 
@@ -37,6 +40,13 @@ namespace gr {
       burst_fnr_filter_impl(filter_mode mode, unsigned int fnr);
       ~burst_fnr_filter_impl();
       void process_burst(pmt::pmt_t msg);
+
+      /* External API */
+      unsigned int get_fn(void);
+      unsigned int set_fn(unsigned int fn);
+
+      filter_mode get_mode(void);
+      filter_mode set_mode(filter_mode mode);
     };
 
   } // namespace gsm

--- a/lib/flow_control/burst_fnr_filter_impl.h
+++ b/lib/flow_control/burst_fnr_filter_impl.h
@@ -34,6 +34,7 @@ namespace gr {
     class burst_fnr_filter_impl : public burst_fnr_filter
     {
      private:
+      filter_policy d_filter_policy;
       unsigned int d_framenr;
       filter_mode d_mode;
      public:
@@ -47,6 +48,10 @@ namespace gr {
 
       filter_mode get_mode(void);
       filter_mode set_mode(filter_mode mode);
+
+      /* Filtering policy */
+      filter_policy get_policy(void);
+      filter_policy set_policy(filter_policy policy);
     };
 
   } // namespace gsm

--- a/lib/flow_control/burst_sdcch_subslot_filter_impl.cc
+++ b/lib/flow_control/burst_sdcch_subslot_filter_impl.cc
@@ -101,5 +101,37 @@ namespace gr {
             message_port_pub(pmt::mp("out"), msg);
         }
     }
+
+    /* External API */
+    unsigned int
+    burst_sdcch_subslot_filter_impl::get_ss(void)
+    {
+      return d_subslot;
+    }
+
+    unsigned int
+    burst_sdcch_subslot_filter_impl::set_ss(unsigned int ss)
+    {
+      if ((d_mode == SS_FILTER_SDCCH8 && ss < 8)
+      || (d_mode == SS_FILTER_SDCCH4 && ss < 4))
+        d_subslot = ss;
+
+      return d_subslot;
+    }
+
+
+    subslot_filter_mode
+    burst_sdcch_subslot_filter_impl::get_mode(void)
+    {
+      return d_mode;
+    }
+
+    subslot_filter_mode
+    burst_sdcch_subslot_filter_impl::set_mode(subslot_filter_mode mode)
+    {
+      d_mode = mode;
+      return d_mode;
+    }
+
   } /* namespace gsm */
 } /* namespace gr */

--- a/lib/flow_control/burst_sdcch_subslot_filter_impl.cc
+++ b/lib/flow_control/burst_sdcch_subslot_filter_impl.cc
@@ -48,7 +48,8 @@ namespace gr {
               gr::io_signature::make(0, 0, 0),
               gr::io_signature::make(0, 0, 0)),
       d_mode(mode),
-      d_subslot(subslot)
+      d_subslot(subslot),
+      d_filter_policy(FILTER_POLICY_DEFAULT)
     {     
         message_port_register_in(pmt::mp("in"));
         message_port_register_out(pmt::mp("out"));
@@ -73,6 +74,14 @@ namespace gr {
           0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,-1,-1,-1,
           0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7,-1,-1,-1
         };
+
+        if (d_filter_policy == FILTER_POLICY_DROP_ALL)
+          return;
+
+        if (d_filter_policy == FILTER_POLICY_PASS_ALL) {
+          message_port_pub(pmt::mp("out"), msg);
+          return;
+        }
     
         pmt::pmt_t header_plus_burst = pmt::cdr(msg);
         gsmtap_hdr * header = (gsmtap_hdr *)pmt::blob_data(header_plus_burst);
@@ -131,6 +140,20 @@ namespace gr {
     {
       d_mode = mode;
       return d_mode;
+    }
+
+    /* Filtering policy */
+    filter_policy
+    burst_sdcch_subslot_filter_impl::get_policy(void)
+    {
+      return d_filter_policy;
+    }
+
+    filter_policy
+    burst_sdcch_subslot_filter_impl::set_policy(filter_policy policy)
+    {
+      d_filter_policy = policy;
+      return d_filter_policy;
     }
 
   } /* namespace gsm */

--- a/lib/flow_control/burst_sdcch_subslot_filter_impl.h
+++ b/lib/flow_control/burst_sdcch_subslot_filter_impl.h
@@ -37,6 +37,13 @@ namespace gr {
       burst_sdcch_subslot_filter_impl(subslot_filter_mode mode, unsigned int subslot);
       ~burst_sdcch_subslot_filter_impl();
       void process_burst(pmt::pmt_t msg);
+
+      /* External API */
+      unsigned int get_ss(void);
+      unsigned int set_ss(unsigned int ss);
+
+      subslot_filter_mode get_mode(void);
+      subslot_filter_mode set_mode(subslot_filter_mode mode);
     };
 
   } // namespace gsm

--- a/lib/flow_control/burst_sdcch_subslot_filter_impl.h
+++ b/lib/flow_control/burst_sdcch_subslot_filter_impl.h
@@ -31,6 +31,7 @@ namespace gr {
     class burst_sdcch_subslot_filter_impl : public burst_sdcch_subslot_filter
     {
      private:
+      filter_policy d_filter_policy;
       subslot_filter_mode d_mode;
       unsigned int d_subslot;
      public:
@@ -44,6 +45,10 @@ namespace gr {
 
       subslot_filter_mode get_mode(void);
       subslot_filter_mode set_mode(subslot_filter_mode mode);
+
+      /* Filtering policy */
+      filter_policy get_policy(void);
+      filter_policy set_policy(filter_policy policy);
     };
 
   } // namespace gsm

--- a/lib/flow_control/burst_sdcch_subslot_splitter_impl.cc
+++ b/lib/flow_control/burst_sdcch_subslot_splitter_impl.cc
@@ -141,5 +141,20 @@ namespace gr {
 
         message_port_pub(pmt::mp(port), msg);
     }
+
+    /* External API */
+    splitter_mode
+    burst_sdcch_subslot_splitter_impl::get_mode(void)
+    {
+      return d_mode;
+    }
+
+    splitter_mode
+    burst_sdcch_subslot_splitter_impl::set_mode(splitter_mode mode)
+    {
+      d_mode = mode;
+      return d_mode;
+    }
+
   } /* namespace gsm */
 } /* namespace gr */

--- a/lib/flow_control/burst_sdcch_subslot_splitter_impl.h
+++ b/lib/flow_control/burst_sdcch_subslot_splitter_impl.h
@@ -36,6 +36,10 @@ namespace gr {
       burst_sdcch_subslot_splitter_impl(splitter_mode mode);
       ~burst_sdcch_subslot_splitter_impl();
       void process_burst(pmt::pmt_t msg);
+
+      /* External API */
+      splitter_mode get_mode(void);
+      splitter_mode set_mode(splitter_mode mode);
     };
 
   } // namespace gsm

--- a/lib/flow_control/burst_timeslot_filter_impl.cc
+++ b/lib/flow_control/burst_timeslot_filter_impl.cc
@@ -48,7 +48,8 @@ namespace gr {
       : gr::block("burst_timeslot_filter",
               gr::io_signature::make(0, 0, 0),
               gr::io_signature::make(0, 0, 0)),
-       d_timeslot(timeslot)
+       d_timeslot(timeslot),
+       d_filter_policy(FILTER_POLICY_DEFAULT)
     {
         message_port_register_in(pmt::mp("in"));        
         message_port_register_out(pmt::mp("out"));
@@ -63,6 +64,14 @@ namespace gr {
 
     void burst_timeslot_filter_impl::process_burst(pmt::pmt_t msg)
     {
+        if (d_filter_policy == FILTER_POLICY_DROP_ALL)
+          return;
+
+        if (d_filter_policy == FILTER_POLICY_PASS_ALL) {
+          message_port_pub(pmt::mp("out"), msg);
+          return;
+        }
+
         pmt::pmt_t header_plus_burst = pmt::cdr(msg);
         gsmtap_hdr * header = (gsmtap_hdr *)pmt::blob_data(header_plus_burst);
         
@@ -90,6 +99,20 @@ namespace gr {
         d_timeslot = tn;
 
       return d_timeslot;
+    }
+
+    /* Filtering policy */
+    filter_policy
+    burst_timeslot_filter_impl::get_policy(void)
+    {
+      return d_filter_policy;
+    }
+
+    filter_policy
+    burst_timeslot_filter_impl::set_policy(filter_policy policy)
+    {
+      d_filter_policy = policy;
+      return d_filter_policy;
     }
 
   } /* namespace gsm */

--- a/lib/flow_control/burst_timeslot_filter_impl.cc
+++ b/lib/flow_control/burst_timeslot_filter_impl.cc
@@ -73,5 +73,24 @@ namespace gr {
             message_port_pub(pmt::mp("out"), msg);
         }
     }
+
+    /*
+     * External API
+     */
+    unsigned int
+    burst_timeslot_filter_impl::get_tn(void)
+    {
+      return d_timeslot;
+    }
+
+    unsigned int
+    burst_timeslot_filter_impl::set_tn(unsigned int tn)
+    {
+      if (tn < 8)
+        d_timeslot = tn;
+
+      return d_timeslot;
+    }
+
   } /* namespace gsm */
 } /* namespace gr */

--- a/lib/flow_control/burst_timeslot_filter_impl.h
+++ b/lib/flow_control/burst_timeslot_filter_impl.h
@@ -36,6 +36,10 @@ namespace gr {
       burst_timeslot_filter_impl(unsigned int timeslot);
       ~burst_timeslot_filter_impl();
       void process_burst(pmt::pmt_t msg);
+
+      /* External API */
+      unsigned int get_tn(void);
+      unsigned int set_tn(unsigned int tn);
     };
 
   } // namespace gsm

--- a/lib/flow_control/burst_timeslot_filter_impl.h
+++ b/lib/flow_control/burst_timeslot_filter_impl.h
@@ -31,6 +31,7 @@ namespace gr {
     class burst_timeslot_filter_impl : public burst_timeslot_filter
     {
      private:
+      filter_policy d_filter_policy;
       unsigned int d_timeslot;
      public:
       burst_timeslot_filter_impl(unsigned int timeslot);
@@ -40,6 +41,10 @@ namespace gr {
       /* External API */
       unsigned int get_tn(void);
       unsigned int set_tn(unsigned int tn);
+
+      /* Filtering policy */
+      filter_policy get_policy(void);
+      filter_policy set_policy(filter_policy policy);
     };
 
   } // namespace gsm

--- a/lib/flow_control/dummy_burst_filter_impl.h
+++ b/lib/flow_control/dummy_burst_filter_impl.h
@@ -35,10 +35,16 @@ namespace gr {
      private:
       bool is_dummy_burst(int8_t *burst, size_t burst_len);
       static const int8_t d_dummy_burst[];
+      filter_policy d_filter_policy;
      public:
       dummy_burst_filter_impl();
       ~dummy_burst_filter_impl();
       void process_burst(pmt::pmt_t msg);
+
+      /* External API */
+      /* Filtering policy */
+      filter_policy get_policy(void);
+      filter_policy set_policy(filter_policy policy);
     };
 
   } // namespace gsm

--- a/swig/grgsm_swig.i
+++ b/swig/grgsm_swig.i
@@ -16,6 +16,7 @@
 #include "grgsm/decryption/decryption.h"
 #include "grgsm/demapping/universal_ctrl_chans_demapper.h"
 #include "grgsm/demapping/tch_f_chans_demapper.h"
+#include "grgsm/flow_control/common.h"
 #include "grgsm/flow_control/burst_timeslot_splitter.h"
 #include "grgsm/flow_control/burst_sdcch_subslot_splitter.h"
 #include "grgsm/flow_control/burst_timeslot_filter.h"
@@ -63,6 +64,7 @@ GR_SWIG_BLOCK_MAGIC2(gsm, universal_ctrl_chans_demapper);
 %include "grgsm/demapping/tch_f_chans_demapper.h"
 GR_SWIG_BLOCK_MAGIC2(gsm, tch_f_chans_demapper);
 
+%include "grgsm/flow_control/common.h"
 %include "grgsm/flow_control/burst_timeslot_splitter.h"
 GR_SWIG_BLOCK_MAGIC2(gsm, burst_timeslot_splitter);
 %include "grgsm/flow_control/burst_sdcch_subslot_splitter.h"


### PR DESCRIPTION
This change implements a simple GET/SET API, which allows to reconfigure block parameters (such as timeslot index in case of timeslot filter) after initialization 'on fly'. Moreover, two new filtering policies was implemented, which make filter either unconditionally pass or drop all the data one gets to the input.