### PR TITLE
In channel_info, threat undefined arfcn as -1.

### DIFF
--- a/apps/grgsm_scanner
+++ b/apps/grgsm_scanner
@@ -249,6 +249,8 @@ class wideband_scanner(gr.top_block):
 
 class channel_info(object):
     def __init__(self, arfcn, freq, cid, lac, mcc, mnc, ccch_conf, power, neighbours, cell_arfcns):
+        if not arfcn:
+            arfcn = -1
         self.arfcn = arfcn
         self.freq = freq
         self.cid = cid
@@ -288,7 +290,7 @@ class channel_info(object):
             return self.getKey().__cmp__(other.getKey())
 
     def __repr__(self):
-        return "ARFCN: %4u, Freq: %6.1fM, CID: %5u, LAC: %5u, MCC: %3u, MNC: %3u, Pwr: %3i" % (
+        return "ARFCN: %4d, Freq: %6.1fM, CID: %5u, LAC: %5u, MCC: %3u, MNC: %3u, Pwr: %3i" % (
             self.arfcn, self.freq / 1e6, self.cid, self.lac, self.mcc, self.mnc, self.power)
 
 


### PR DESCRIPTION
When arfcn is None, __cmp__() and __repr__() will throw a TypeError
exception, as reported in issue #252.  By making sure arfcn is never
None, the problem do not occur.