### PR TITLE
Fix fatal typo in channel_info.__repr__().

### DIFF
--- a/apps/grgsm_scanner
+++ b/apps/grgsm_scanner
@@ -288,7 +288,7 @@ class channel_info(object):
             return self.getKey().__cmp__(other.getKey())
 
     def __repr__(self):
-        return "%s(%s, %s, %s, %s, %s, %s, %s, %s, %s)" % (
+        return "%s(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)" % (
             self.__class__, self.arfcn, self.freq, self.cid, self.lac,
             self.mcc, self.mnc, self.ccch_conf, self.power,
             self.neighbours, self.cell_arfcns)


### PR DESCRIPTION
The format list is one value too short.  Add the missing %s.