### PR TITLE
endian.h file path fixed.

### DIFF
--- a/lib/decoding/osmocom/coding/gsm0503_coding.c
+++ b/lib/decoding/osmocom/coding/gsm0503_coding.c
@@ -33,7 +33,7 @@ extern "C" {
 #include <osmocom/core/conv.h>
 #include <osmocom/core/utils.h>
 #include <osmocom/core/crcgen.h>
-#include <osmocom/core/endian.h>
+#include <grgsm/endian.h>
 
 #include <osmocom/gsm/protocol/gsm_04_08.h>
 #include "gsm0503.h"


### PR DESCRIPTION
In OSX endian.h file not found error occured because of not getting this file,In this commit the file path is fixed and working correctly.