### PR TITLE
preprocess_tx_burst: fix the output message

### DIFF
--- a/lib/transmitter/preprocess_tx_burst_impl.cc
+++ b/lib/transmitter/preprocess_tx_burst_impl.cc
@@ -86,7 +86,7 @@ namespace gr {
 
       // Prepare an output message
       pmt::pmt_t blob_out = pmt::make_blob(burst_bits, burst_len);
-      pmt::pmt_t msg_out = pmt::cons(pmt::PMT_NIL, blob_out);
+      pmt::pmt_t msg_out = pmt::cons(pmt::car(msg_in), blob_out);
 
       /* Send a message to the output */
       message_port_pub(pmt::mp("bursts_out"), msg_out);


### PR DESCRIPTION
During the code refactoring (4bd990b), the first part of the
output message was accidently dropped. Let's fix this.