### PR TITLE
Return early on error to match the previous behavior (#353)

### DIFF
--- a/lib/decoding/control_channels_decoder_impl.cc
+++ b/lib/decoding/control_channels_decoder_impl.cc
@@ -105,7 +105,7 @@ namespace gr {
             //convert to soft bits
             ubits2sbits(bursts_u, bursts_s, 116 * 4);
             //decode
-            gsm0503_xcch_decode(result, bursts_s, &n_errors, &n_bits_total);
+            if (gsm0503_xcch_decode(result, bursts_s, &n_errors, &n_bits_total) != 0) return;
 
             //extract header of the first burst of the four bursts
             pmt::pmt_t first_header_plus_burst = pmt::cdr(d_bursts[0]);
@@ -120,7 +120,6 @@ namespace gr {
             //send message to the output
             message_port_pub(pmt::mp("msgs"), msg_out);
         }
-        return;
     }
   } /* namespace gsm */
 } /* namespace gr */


### PR DESCRIPTION
Removed unnecessary return statement at the end of the function. The return type is void.
~~Some bursts are different before and after the said commit in #353. This doesn't seem to affect the resulting data, as they seem to be corrupt anyway.~~
Note: There are updates to "lib/decoding/osmocom/coding/" at the upstream. I don't know if they're needed for something, though.

Happy holidays!

Edit (Note):
Bursts, which look like they're corrupt, can be different on each run.
Also, the resulting data can be in the middle of the bursts instead at the end of each group.
Is this an expected behavior?

Many thanks in advance!

Signed-off-by: Christian Inci <chris.gh@broke-the-inter.net>