### PR TITLE
 Add HR demapping

### DIFF
--- a/grc/demapping/gsm_tch_f_chans_demapper.xml
+++ b/grc/demapping/gsm_tch_f_chans_demapper.xml
@@ -3,15 +3,40 @@
   <name>TCH/F Demapper</name>
   <key>gsm_tch_f_chans_demapper</key>
   <import>import grgsm</import>
-  <make>grgsm.tch_f_chans_demapper($timeslot_nr)</make>
+  <make>grgsm.tch_f_chans_demapper($timeslot_nr, $tch_type, $tch_h_channel)</make>
 
   <param>
-    <name>timeslot_nr</name>
+    <name>Timeslot</name>
     <key>timeslot_nr</key>
     <value>2</value>
     <type>int</type>
     <hide>part</hide>
   </param>
+
+  <param>
+    <name>TCH Type</name>
+    <key>tch_type</key>
+    <value>0</value>
+    <type>int</type>
+    <hide>part</hide>
+    <option>
+      <name>Full rate</name>
+      <key>0</key>
+    </option>
+    <option>
+      <name>Half rate</name>
+      <key>1</key>
+    </option>
+  </param>
+
+  <param>
+    <name>TCH/H Channel</name>
+    <key>tch_h_channel</key>
+    <value>0</value>
+    <type>int</type>
+    <hide>#if $tch_type() == 0 then 'all' else 'none'#</hide>
+  </param>
+  <check>$tch_h_channel() &gt; -1 and $tch_h_channel() &lt; 2</check>
 
   <sink>
     <name>bursts</name>

--- a/include/grgsm/demapping/tch_f_chans_demapper.h
+++ b/include/grgsm/demapping/tch_f_chans_demapper.h
@@ -48,7 +48,7 @@ namespace gr {
        * class. gsm::tch_f_chans_demapper::make is the public interface for
        * creating new instances.
        */
-      static sptr make(unsigned int timeslot_nr);
+      static sptr make(unsigned int timeslot_nr, int tch_type, int tch_h_channel);
     };
 
   } // namespace gsm

--- a/lib/demapping/tch_f_chans_demapper_impl.cc
+++ b/lib/demapping/tch_f_chans_demapper_impl.cc
@@ -32,26 +32,29 @@
 #define BURST_SIZE 148
 
 namespace gr {
-  namespace gsm {
+namespace gsm {
 
-    tch_f_chans_demapper::sptr
-    tch_f_chans_demapper::make(unsigned int timeslot_nr)
-    {
-      return gnuradio::get_initial_sptr
-        (new tch_f_chans_demapper_impl(timeslot_nr));
-    }
+tch_f_chans_demapper::sptr
+tch_f_chans_demapper::make(unsigned int timeslot_nr, int tch_type, int tch_h_channel)
+{
+        return gnuradio::get_initial_sptr
+                       (new tch_f_chans_demapper_impl(timeslot_nr, tch_type, tch_h_channel));
+}
 
-    /*
-     * The private constructor
-     *
-     */
-    tch_f_chans_demapper_impl::tch_f_chans_demapper_impl(unsigned int timeslot_nr)
-      : gr::block("tch_f_chans_demapper",
-              gr::io_signature::make(0, 0, 0),
-              gr::io_signature::make(0, 0, 0)),
-       d_timeslot(timeslot_nr)
+/*
+ * The private constructor
+ *
+ */
+tch_f_chans_demapper_impl::tch_f_chans_demapper_impl(unsigned int timeslot_nr, int tch_type, int tch_h_channel)
+        : gr::block("tch_f_chans_demapper",
+                    gr::io_signature::make(0, 0, 0),
+                    gr::io_signature::make(0, 0, 0)),
+        d_timeslot(timeslot_nr),
+        d_tch_type(tch_type),
+        d_tch_h_channel(tch_h_channel)
 
-    {
+{
+        std::cout << "d_tch_type is " << d_tch_type << ", tch_h_channel is " << tch_h_channel << std::endl;
 //        for (int ii=0; ii<3; ii++)
 //        {
         //            d_bursts_stolen[ii] = false;
@@ -61,17 +64,17 @@ namespace gr {
         set_msg_handler(pmt::mp("bursts"), boost::bind(&tch_f_chans_demapper_impl::filter_tch_chans, this, _1));
         message_port_register_out(pmt::mp("tch_bursts"));
         message_port_register_out(pmt::mp("acch_bursts"));
-    }
+}
 
-    /*
-     * Our virtual destructor.
-     */
-    tch_f_chans_demapper_impl::~tch_f_chans_demapper_impl()
-    {
-    }
+/*
+ * Our virtual destructor.
+ */
+tch_f_chans_demapper_impl::~tch_f_chans_demapper_impl()
+{
+}
 
-    void tch_f_chans_demapper_impl::filter_tch_chans(pmt::pmt_t msg)
-    {
+void tch_f_chans_demapper_impl::filter_tch_chans(pmt::pmt_t msg)
+{
         pmt::pmt_t header_plus_burst = pmt::cdr(msg);
         gsmtap_hdr * header = (gsmtap_hdr *)pmt::blob_data(header_plus_burst);
 
@@ -80,165 +83,279 @@ namespace gr {
         uint32_t fn_mod13 = frame_nr % 13;
         int8_t * burst_bits = (int8_t *)(pmt::blob_data(header_plus_burst))+sizeof(gsmtap_hdr);
 
-        if(header->timeslot == d_timeslot){
-            int8_t new_msg[sizeof(gsmtap_hdr)+BURST_SIZE];
-            gsmtap_hdr * new_hdr = (gsmtap_hdr*)new_msg;
-            memcpy(new_msg, header, sizeof(gsmtap_hdr)+BURST_SIZE);
+        if(header->timeslot == d_timeslot) {
+                int8_t new_msg[sizeof(gsmtap_hdr)+BURST_SIZE];
+                gsmtap_hdr * new_hdr = (gsmtap_hdr*)new_msg;
+                memcpy(new_msg, header, sizeof(gsmtap_hdr)+BURST_SIZE);
 
-            new_hdr->sub_type = GSMTAP_CHANNEL_TCH_F;
-            if (fn_mod13 == 12)
-                new_hdr->sub_type = GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_TCH_F;
+                new_hdr->sub_type = GSMTAP_CHANNEL_TCH_F;
+                if (fn_mod13 == 12)
+                        new_hdr->sub_type = GSMTAP_CHANNEL_ACCH|GSMTAP_CHANNEL_TCH_F;
 
-            pmt::pmt_t msg_binary_blob = pmt::make_blob(new_msg,sizeof(gsmtap_hdr)+BURST_SIZE);
-            pmt::pmt_t msg_out = pmt::cons(pmt::PMT_NIL, msg_binary_blob);
+                pmt::pmt_t msg_binary_blob = pmt::make_blob(new_msg,sizeof(gsmtap_hdr)+BURST_SIZE);
+                pmt::pmt_t msg_out = pmt::cons(pmt::PMT_NIL, msg_binary_blob);
 
-            //distinguishing uplink and downlink bursts
-            bool uplink_burst = (be16toh(header->arfcn) & 0x4000) ? true : false;
+                //distinguishing uplink and downlink bursts
+                bool uplink_burst = (be16toh(header->arfcn) & 0x4000) ? true : false;
 
-            if(uplink_burst)
-            {
-                sacch_tch_demapper(fn_mod13, fn_mod26, frame_nr,d_bursts_sacch_ul,
-                                   d_frame_numbers_sacch_ul, d_bursts_ul, d_frame_numbers_ul, msg_out);
-            }
-            else
-            {
-                sacch_tch_demapper(fn_mod13, fn_mod26, frame_nr,d_bursts_sacch_dl,
-                                   d_frame_numbers_sacch_dl, d_bursts_dl, d_frame_numbers_dl, msg_out);
-            }
+                if(uplink_burst)
+                {
+                        sacch_tch_demapper(fn_mod13, fn_mod26, frame_nr,d_bursts_sacch_ul,
+                                           d_frame_numbers_sacch_ul, d_bursts_ul, d_frame_numbers_ul, msg_out);
+                }
+                else
+                {
+                        sacch_tch_demapper(fn_mod13, fn_mod26, frame_nr,d_bursts_sacch_dl,
+                                           d_frame_numbers_sacch_dl, d_bursts_dl, d_frame_numbers_dl, msg_out);
+                }
 
         }
-    }
+}
 
-    void tch_f_chans_demapper_impl::sacch_tch_demapper(uint32_t fn_mod13, u_int32_t fn_mod26, uint32_t frame_nr,
-                                                       pmt::pmt_t *d_bursts_sacch,
-                                                       uint32_t *d_frame_numbers_sacch, pmt::pmt_t d_bursts[3][8],
-                                                       uint32_t d_frame_numbers[3][8], pmt::pmt_t msg_out)
-    {
+void tch_f_chans_demapper_impl::sacch_tch_demapper(uint32_t fn_mod13, u_int32_t fn_mod26, uint32_t frame_nr,
+                                                   pmt::pmt_t *d_bursts_sacch,
+                                                   uint32_t *d_frame_numbers_sacch, pmt::pmt_t d_bursts[3][8],
+                                                   uint32_t d_frame_numbers[3][8], pmt::pmt_t msg_out)
+{
         bool frames_are_consecutive = true;
         if (fn_mod13 == 12)
         {
-            // position of SACCH burst based on timeslot
-            // see specification gsm 05.02
-            uint32_t index;
-            bool is_sacch = false;
+                // position of SACCH burst based on timeslot
+                // see specification gsm 05.02
+                uint32_t index;
+                bool is_sacch = false;
 
-            if (d_timeslot % 2 == 0 && fn_mod26 == 12)
-            {
-                index = (((frame_nr - 12) / 26) - (d_timeslot / 2)) % 4;
-                is_sacch = true;
-            }
-            else if (d_timeslot % 2 == 1 && fn_mod26 == 25)
-            {
-                index = (((frame_nr - 25) / 26) - ((d_timeslot - 1) / 2)) % 4;
-                is_sacch = true;
-            }
-
-            if (is_sacch)
-            {
-                d_bursts_sacch[index] = msg_out;
-                d_frame_numbers_sacch[index] = frame_nr;
-
-                if (index == 3)
+                if (d_timeslot % 2 == 0 && fn_mod26 == 12)
                 {
-                    //check for a situation where some bursts were lost
-                    //in this situation frame numbers won't be consecutive
-                    frames_are_consecutive = true;
-                    for(int jj=1; jj<4; jj++)
-                    {
-                        if((d_frame_numbers_sacch[jj]-d_frame_numbers_sacch[jj-1]) != 26)
-                        {
-                            frames_are_consecutive = false;
-                        }
-                    }
-                    if(frames_are_consecutive)
-                    {
-                        //send bursts to the output
-                        for(int jj=0; jj<4; jj++)
-                        {
-                            message_port_pub(pmt::mp("acch_bursts"), d_bursts_sacch[jj]);
-                        }
-                    }
+                        index = (((frame_nr - 12) / 26) - (d_timeslot / 2)) % 4;
+                        is_sacch = true;
                 }
-            }
+                else if (d_timeslot % 2 == 1 && fn_mod26 == 25)
+                {
+                        index = (((frame_nr - 25) / 26) - ((d_timeslot - 1) / 2)) % 4;
+                        is_sacch = true;
+                }
+
+                if (is_sacch)
+                {
+                        d_bursts_sacch[index] = msg_out;
+                        d_frame_numbers_sacch[index] = frame_nr;
+
+                        if (index == 3)
+                        {
+                                //check for a situation where some bursts were lost
+                                //in this situation frame numbers won't be consecutive
+                                frames_are_consecutive = true;
+                                for(int jj=1; jj<4; jj++)
+                                {
+                                        if((d_frame_numbers_sacch[jj]-d_frame_numbers_sacch[jj-1]) != 26)
+                                        {
+                                                frames_are_consecutive = false;
+                                        }
+                                }
+                                if(frames_are_consecutive)
+                                {
+                                        //send bursts to the output
+                                        for(int jj=0; jj<4; jj++)
+                                        {
+                                                message_port_pub(pmt::mp("acch_bursts"), d_bursts_sacch[jj]);
+                                        }
+                                }
+                        }
+                }
         }
         else
         {
-            if (fn_mod13 <= 3)
-            {
-                // add to b1 and b3
-                d_bursts[0][fn_mod13] = msg_out;
-                d_bursts[2][fn_mod13 + 4] = msg_out;
-
-                // set framenumber for later checking of continuity
-                d_frame_numbers[0][fn_mod13] = frame_nr;
-                d_frame_numbers[2][fn_mod13 + 4] = frame_nr;
-            }
-            else if (fn_mod13 >= 4 && fn_mod13 <= 7)
-            {
-                // add to b1 and b2
-                d_bursts[0][fn_mod13] = msg_out;
-                d_bursts[1][fn_mod13 - 4] = msg_out;
-
-                // set framenumber for later checking of continuity
-                d_frame_numbers[0][fn_mod13] = frame_nr;
-                d_frame_numbers[1][fn_mod13 - 4] = frame_nr;
-            }
-            else if (fn_mod13 >= 8 && fn_mod13 <= 11)
-            {
-                // add to b2 and b3
-                d_bursts[1][fn_mod13 - 4] = msg_out;
-                d_bursts[2][fn_mod13 - 8] = msg_out;
-
-                // set framenumber for later checking of continuity
-                d_frame_numbers[1][fn_mod13 - 4] = frame_nr;
-                d_frame_numbers[2][fn_mod13 - 8] = frame_nr;
-            }
-
-            // send burst 1 or burst 2 to output
-            if (fn_mod13 == 3 || fn_mod13 == 7 || fn_mod13 == 11)
-            {
-                int tch_burst_nr = 0;
-
-                if (fn_mod13 == 11)
-                {
-                    tch_burst_nr = 1;
-                }
-                else if (fn_mod13 == 3)
-                {
-                    tch_burst_nr = 2;
-                }
-
-                //check for a situation where some bursts were lost
-                //in this situation frame numbers won't be consecutive
-                frames_are_consecutive = true;
-
-                for(int jj=1; jj<8; jj++)
-                {
-                    if (((d_frame_numbers[tch_burst_nr][jj] - d_frame_numbers[tch_burst_nr][jj-1]) != 1) && frames_are_consecutive)
-                    {
-                        frames_are_consecutive = false;
-                        // burst 3 has 1 sacch burst in between
-                        if (tch_burst_nr == 2 && jj == 4
-                            && d_frame_numbers[tch_burst_nr][jj] - d_frame_numbers[tch_burst_nr][jj - 1] == 2)
-                        {
-                            frames_are_consecutive = true;
+                if(d_tch_type==1) {
+                        bool our_sub=false;
+                        // So, here I change the fn_mod13, with this changes I can
+                        // process both subslot (d_tch_h_channel) with the same code.
+                        //
+                        // Theory about this on github
+                        //
+                        // Example:
+                        //
+                        // For subslot=0 our burst is 0,2,4,6 etc
+                        // For subslot=1 it 1,3,5 etc
+                        // But if we change it with this code,
+                        // both will be 0,1,2,3,4 etc
+                        // And we can proced two subslot like one.
+                        if(fn_mod13%2==d_tch_h_channel) {
+                                if(d_tch_h_channel==0) {
+                                        fn_mod13=fn_mod13/2;
+                                }else{
+                                        fn_mod13-=1;
+                                        fn_mod13=fn_mod13/2;
+                                }
+                                // We work only with our subslot
+                                our_sub=true;
                         }
-                    }
-                }
+                        if(our_sub) {
 
-                if(frames_are_consecutive)
-                {
-                    //send bursts to the output
-                    for(int jj=0; jj<8; jj++)
-                    {
-                        message_port_pub(pmt::mp("tch_bursts"), d_bursts[tch_burst_nr][jj]);
-                    }
-                    // useless
+                                if (fn_mod13 <= 1)
+                                {
+                                        // add to b1 and b3
+                                        d_bursts[0][fn_mod13] = msg_out;
+                                        d_bursts[2][fn_mod13+2] = msg_out;
+
+
+
+                                        d_frame_numbers[0][fn_mod13] = frame_nr;
+                                        d_frame_numbers[2][fn_mod13+2] = frame_nr;
+                                }
+                                else if (fn_mod13 >=2 && fn_mod13 <=3)
+                                {
+                                        // add to b1 and b2
+                                        d_bursts[0][fn_mod13] = msg_out;
+                                        d_bursts[1][fn_mod13-2] = msg_out;
+
+
+                                        d_frame_numbers[0][fn_mod13] = frame_nr;
+                                        d_frame_numbers[1][fn_mod13-2] = frame_nr;
+                                        //d_frame_numbers[1][fn_mod13 - 4] = frame_nr;
+                                }
+                                else if (fn_mod13 >=4 && fn_mod13 <=5)
+                                {
+                                        // add to b1 and b2
+                                        d_bursts[1][fn_mod13-2] = msg_out;
+                                        d_bursts[2][fn_mod13-4] = msg_out;
+
+
+
+                                        d_frame_numbers[1][fn_mod13-2] = frame_nr;
+                                        d_frame_numbers[2][fn_mod13-4] = frame_nr;
+                                        //d_frame_numbers[1][fn_mod13 - 4] = frame_nr;
+                                }
+                                // send burst 1 or burst 2 to output
+                                //if ( fn_mod26 == 2 || fn_mod26 == 5 || fn_mod26 == 9)
+                                if(fn_mod13 == 1 || fn_mod13 == 3|| fn_mod13 == 5)
+                                {
+                                        int tch_burst_nr = 0;
+
+                                        if(fn_mod13==5) {
+                                                tch_burst_nr = 1;
+                                        }
+                                        if(fn_mod13==1) {
+                                                tch_burst_nr = 2;
+                                        }
+
+                                        //check for a situation where some bursts were lost
+                                        //in this situation frame numbers won't be consecutive
+                                        frames_are_consecutive = true;
+                                        // std::cout<<"br="<<tch_burst_nr<<" Array: ";
+                                        // std::cout<<d_frame_numbers[tch_burst_nr][0]<<" ";
+                                        bool one_tree=true;
+                                        for(int jj=1; jj<4; jj++)
+                                        {
+
+                                                if (((d_frame_numbers[tch_burst_nr][jj] - d_frame_numbers[tch_burst_nr][jj-1]) != 2) && frames_are_consecutive)
+                                                {
+                                                        frames_are_consecutive = false;
+
+                                                        if (tch_burst_nr == 2 && jj == 2
+                                                            && d_frame_numbers[tch_burst_nr][jj] - d_frame_numbers[tch_burst_nr][jj - 1] == 3)
+                                                        {
+                                                                //  std::cout<<" YEAH ";
+                                                                frames_are_consecutive = true;
+                                                        }
+
+                                                }
+                                                //}
+                                        }
+                                        // std::cout<<std::endl;
+
+                                        if(frames_are_consecutive)
+                                        {
+
+                                                for(int jj=0; jj<4; jj++)
+                                                {
+
+                                                        message_port_pub(pmt::mp("tch_bursts"), d_bursts[tch_burst_nr][jj]);
+                                                }
+
+                                                // useless
+                                                //                        d_bursts_stolen[tch_burst_nr] = false;
+                                        }
+                                }
+                        }
+
+                }else{
+                        if (fn_mod13 <= 3)
+                        {
+                                // add to b1 and b3
+                                d_bursts[0][fn_mod13] = msg_out;
+                                d_bursts[2][fn_mod13 + 4] = msg_out;
+
+                                // set framenumber for later checking of continuity
+                                d_frame_numbers[0][fn_mod13] = frame_nr;
+                                d_frame_numbers[2][fn_mod13 + 4] = frame_nr;
+                        }
+                        else if (fn_mod13 >= 4 && fn_mod13 <= 7)
+                        {
+                                // add to b1 and b2
+                                d_bursts[0][fn_mod13] = msg_out;
+                                d_bursts[1][fn_mod13 - 4] = msg_out;
+
+                                // set framenumber for later checking of continuity
+                                d_frame_numbers[0][fn_mod13] = frame_nr;
+                                d_frame_numbers[1][fn_mod13 - 4] = frame_nr;
+                        }
+                        else if (fn_mod13 >= 8 && fn_mod13 <= 11)
+                        {
+                                // add to b2 and b3
+                                d_bursts[1][fn_mod13 - 4] = msg_out;
+                                d_bursts[2][fn_mod13 - 8] = msg_out;
+
+                                // set framenumber for later checking of continuity
+                                d_frame_numbers[1][fn_mod13 - 4] = frame_nr;
+                                d_frame_numbers[2][fn_mod13 - 8] = frame_nr;
+                        }
+
+                        // send burst 1 or burst 2 to output
+                        if (fn_mod13 == 3 || fn_mod13 == 7 || fn_mod13 == 11)
+                        {
+                                int tch_burst_nr = 0;
+
+                                if (fn_mod13 == 11)
+                                {
+                                        tch_burst_nr = 1;
+                                }
+                                else if (fn_mod13 == 3)
+                                {
+                                        tch_burst_nr = 2;
+                                }
+
+                                //check for a situation where some bursts were lost
+                                //in this situation frame numbers won't be consecutive
+                                frames_are_consecutive = true;
+
+                                for(int jj=1; jj<8; jj++)
+                                {
+                                        if (((d_frame_numbers[tch_burst_nr][jj] - d_frame_numbers[tch_burst_nr][jj-1]) != 1) && frames_are_consecutive)
+                                        {
+                                                frames_are_consecutive = false;
+                                                // burst 3 has 1 sacch burst in between
+                                                if (tch_burst_nr == 2 && jj == 4
+                                                    && d_frame_numbers[tch_burst_nr][jj] - d_frame_numbers[tch_burst_nr][jj - 1] == 2)
+                                                {
+                                                        frames_are_consecutive = true;
+                                                }
+                                        }
+                                }
+
+                                if(frames_are_consecutive)
+                                {
+                                        //send bursts to the output
+                                        for(int jj=0; jj<8; jj++)
+                                        {
+                                                message_port_pub(pmt::mp("tch_bursts"), d_bursts[tch_burst_nr][jj]);
+                                        }
+                                        // useless
 //                        d_bursts_stolen[tch_burst_nr] = false;
+                                }
+                        }
                 }
-            }
         }
-    }
-  } /* namespace gsm */
+}
+}   /* namespace gsm */
 } /* namespace gr */
-

--- a/lib/demapping/tch_f_chans_demapper_impl.h
+++ b/lib/demapping/tch_f_chans_demapper_impl.h
@@ -32,6 +32,8 @@ namespace gr {
     {
      private:
       unsigned int d_timeslot;
+      int d_tch_type;
+      int d_tch_h_channel;
       // Downlink
       uint32_t d_frame_numbers_dl[3][8];       // for checking consecutive frame numbers of tch
       uint32_t d_frame_numbers_sacch_dl[4];    // for checking consecutive frame numbers of sacch
@@ -49,7 +51,7 @@ namespace gr {
                               uint32_t d_frame_numbers[3][8], pmt::pmt_t msg_out);
 
      public:
-      tch_f_chans_demapper_impl(unsigned int timeslot_nr);
+      tch_f_chans_demapper_impl(unsigned int timeslot_nr, int tch_type, int tch_h_channel);
       ~tch_f_chans_demapper_impl();
 
       void filter_tch_chans(pmt::pmt_t msg);


### PR DESCRIPTION
In this commit i tried add functionality for demapping HR. 
## Theory
For basic theory i use [table](http://www.etsi.org/deliver/etsi_gts/05/0502/05.00.00_60/gsmts_0502v050000p.pdf) (Page 23), from which used rules for demapping FR:
```
B0(0...7)
B1(4...11)
B2(8...11,0...3)
```
And if looks at this code then easy compare him with mapped rules.
```C
else if (fn_mod13 >= 4 && fn_mod13 <= 7){                       
  frames_are_consecutive = true;
  // add to b1 and b2
  d_bursts[0][fn_mod13] = msg_out;
  d_bursts[1][fn_mod13 - 4] = msg_out;

  // set framenumber for later checking of continuity
  d_frame_numbers[0][fn_mod13] = frame_nr;
  d_frame_numbers[1][fn_mod13 - 4] = frame_nr;
}
```
Okey, so i copy FR demmaper and adaptive him for works with HR rules:
```
Subslot 0 - B0(0,2,4,6)
            B1(4,6,8,10)
            B2(8,10,0,2)
Subslot 1 - B0(1,3,5,7)
            B1(5,7,9,11)
            B2(9,11,1,3)
```
But i combine two subslot to one with using a small cheat
```C
if(fn_mod13%2==d_tch_h_channel) {
  if(d_tch_h_channel==0) {
    fn_mod13=fn_mod13/2;
  }else{
    fn_mod13-=1;
    fn_mod13=fn_mod13/2;
  }
// We work only with our subslot
our_sub=true;
}
```
With this code i translate odd and even subslot to one. In code i use example
```
For subslot=0 our burst is 0,2,4,6 etc
For subslot=1 it 1,3,5 etc
But if we translet it,
both will be 0,1,2,3,4 etc
And we can proced two subslot like one.
```
## Commit
In commit i use `if` for choose witch code used, but for real work we can make a table index and use one code for HR and FR. Here example
```C
else if (fn_mod13 >= index_table[1] && fn_mod13 <= index_table[2]){
```
## Testing
Code compiled without errors but i haven't HR for testing demapper, so i dont know real steps to testing this. But theory wery simple and code based on existing part.