### PR TITLE
Fix an assert in ViterbiR2O4::decode

### DIFF
--- a/lib/decoding/openbts/ViterbiR204.cpp
+++ b/lib/decoding/openbts/ViterbiR204.cpp
@@ -285,8 +285,8 @@ void ViterbiR2O4::decode(const SoftVector &in, BitVector& target)
 		const ViterbiR2O4::vCand *minCost = NULL;
 		while (op<opt) {
 			// Viterbi algorithm
-			assert(match-matchCostTable<(float)sizeof(matchCostTable)/sizeof(matchCostTable[0])-1);
-			assert(mismatch-mismatchCostTable<(float)sizeof(mismatchCostTable)/sizeof(mismatchCostTable[0])-1);
+			assert(match - matchCostTable < ctsz - 1);
+			assert(mismatch - mismatchCostTable < ctsz - 1);
 			minCost = decoder.vstep(*ip, match, mismatch, oCount < oSize);
 			ip += step;
 			match += step;


### PR DESCRIPTION
The table length was wrong because matchCostTable is a float pointer and not an array since 792330777d7c21df02ce1ecb6f876b076a14b519

I'm testing it with [downlink.cfile](https://mega.nz/#!dyxFnB5D!xEYTGucMhdv-T4rW5oHOtgi9boX5sJbfbfilG5uGNLs) from https://groups.google.com/d/msg/gr-gsm/6VJ6N1YZcHA/tJUHcvYQAQAJ

Here is the full backtrace

```
python2.7: /home/vasko/sources/gr-gsm/gr-gsm/lib/decoding/openbts/ViterbiR204.cpp:288: virtual void ViterbiR2O4::decode(const SoftVector&, BitVector&): Assertion `match-matchCostTable<(float)sizeof(matchCostTable)/sizeof(matchCostTable[0])-1' failed.

Thread 9 "tch_f_decoder13" received signal SIGABRT, Aborted.
[Switching to Thread 0x7fffd57fa700 (LWP 6763)]
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
51	}
Missing separate debuginfos, use: dnf debuginfo-install atlas-3.10.2-16.fc26.x86_64 boost-atomic-1.63.0-11.fc26.x86_64 boost-chrono-1.63.0-11.fc26.x86_64 boost-date-time-1.63.0-11.fc26.x86_64 boost-filesystem-1.63.0-11.fc26.x86_64 boost-program-options-1.63.0-11.fc26.x86_64 boost-regex-1.63.0-11.fc26.x86_64 boost-system-1.63.0-11.fc26.x86_64 boost-thread-1.63.0-11.fc26.x86_64 fftw-libs-single-3.3.5-4.fc26.x86_64 gnuradio-3.7.11-1.fc26.x86_64 libtalloc-2.1.11-1.fc26.x86_64 orc-0.4.27-1.fc26.x86_64 python2-numpy-1.12.1-1.fc26.x86_64
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff6cbb800 in __GI_abort () at abort.c:89
#2  0x00007ffff6cb20da in __assert_fail_base (fmt=0x7ffff6e1ea78 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", 
    assertion=assertion@entry=0x7fffdfff7b00 "match-matchCostTable<(float)sizeof(matchCostTable)/sizeof(matchCostTable[0])-1", 
    file=file@entry=0x7fffdfff7a60 "/home/vasko/sources/gr-gsm/gr-gsm/lib/decoding/openbts/ViterbiR204.cpp", line=line@entry=288, 
    function=function@entry=0x7fffdfff7d60 <ViterbiR2O4::decode(SoftVector const&, BitVector&)::__PRETTY_FUNCTION__> "virtual void ViterbiR2O4::decode(const SoftVector&, BitVector&)") at assert.c:92
#3  0x00007ffff6cb2152 in __GI___assert_fail (
    assertion=0x7fffdfff7b00 "match-matchCostTable<(float)sizeof(matchCostTable)/sizeof(matchCostTable[0])-1", 
    file=0x7fffdfff7a60 "/home/vasko/sources/gr-gsm/gr-gsm/lib/decoding/openbts/ViterbiR204.cpp", line=288, 
    function=0x7fffdfff7d60 <ViterbiR2O4::decode(SoftVector const&, BitVector&)::__PRETTY_FUNCTION__> "virtual void ViterbiR2O4::decode(const SoftVector&, BitVector&)") at assert.c:101
#4  0x00007fffdff820c3 in ViterbiR2O4::decode (this=0x5555563bbdf0, in=..., target=...)
    at /home/vasko/sources/gr-gsm/gr-gsm/lib/decoding/openbts/ViterbiR204.cpp:288
#5  0x00007fffdff8a4bb in gr::gsm::tch_f_decoder_impl::decode (this=0x5555563bb8b0, msg=...)
    at /home/vasko/sources/gr-gsm/gr-gsm/lib/decoding/tch_f_decoder_impl.cc:167
#6  0x00007fffdff8cdd5 in boost::_mfi::mf1<void, gr::gsm::tch_f_decoder_impl, boost::intrusive_ptr<pmt::pmt_base> >::operator() (
    this=0x5555563ac2b0, p=0x5555563bb8b0, a1=...) at /usr/include/boost/bind/mem_fn_template.hpp:165
#7  0x00007fffdff8cb94 in boost::_bi::list2<boost::_bi::value<gr::gsm::tch_f_decoder_impl*>, boost::arg<1> >::operator()<boost::_mfi::mf1<void, gr::gsm::tch_f_decoder_impl, boost::intrusive_ptr<pmt::pmt_base> >, boost::_bi::rrlist1<boost::intrusive_ptr<pmt::pmt_base> > > (this=0x5555563ac2c0, 
    f=..., a=...) at /usr/include/boost/bind/bind.hpp:319
#8  0x00007fffdff8ca4a in boost::_bi::bind_t<void, boost::_mfi::mf1<void, gr::gsm::tch_f_decoder_impl, boost::intrusive_ptr<pmt::pmt_base> >, boost::_bi::list2<boost::_bi::value<gr::gsm::tch_f_decoder_impl*>, boost::arg<1> > >::operator()<boost::intrusive_ptr<pmt::pmt_base> > (this=0x5555563ac2b0, 
    a1=...) at /usr/include/boost/bind/bind.hpp:1306
#9  0x00007fffdff8c98d in boost::detail::function::void_function_obj_invoker1<boost::_bi::bind_t<void, boost::_mfi::mf1<void, gr::gsm::tch_f_decoder_impl, boost::intrusive_ptr<pmt::pmt_base> >, boost::_bi::list2<boost::_bi::value<gr::gsm::tch_f_decoder_impl*>, boost::arg<1> > >, void, boost::intrusive_ptr<pmt::pmt_base> >::invoke (function_obj_ptr=..., a0=...) at /usr/include/boost/function/function_template.hpp:159
#10 0x00007fffdff8431c in boost::function1<void, boost::intrusive_ptr<pmt::pmt_base> >::operator() (this=0x5555563ac2a8, a0=...)
    at /usr/include/boost/function/function_template.hpp:770
#11 0x00007fffdff83b7e in gr::basic_block::dispatch_msg (this=0x5555563bc648, which_port=..., msg=...) at /usr/include/gnuradio/basic_block.h:134
#12 0x00007fffef1c53e8 in gr::tpb_thread_body::tpb_thread_body(boost::shared_ptr<gr::block>, int) () from /lib64/libgnuradio-runtime-3.7.11.so.0.0.0
#13 0x00007fffef1b7e23 in boost::detail::function::void_function_obj_invoker0<gr::thread::thread_body_wrapper<gr::tpb_container>, void>::invoke(boost::detail::function::function_buffer&) () from /lib64/libgnuradio-runtime-3.7.11.so.0.0.0
#14 0x00007fffef1698f2 in boost::detail::thread_data<boost::function0<void> >::run() () from /lib64/libgnuradio-runtime-3.7.11.so.0.0.0
#15 0x00007fffed8ca2fd in thread_proxy () from /lib64/libboost_thread.so.1.63.0
#16 0x00007ffff777c36d in start_thread (arg=0x7fffd57fa700) at pthread_create.c:456
#17 0x00007ffff6d93b4f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
(gdb) f 4
#4  0x00007fffdff820c3 in ViterbiR2O4::decode (this=0x5555563bbdf0, in=..., target=...)
    at /home/vasko/sources/gr-gsm/gr-gsm/lib/decoding/openbts/ViterbiR204.cpp:288
288				assert(match-matchCostTable<(float)sizeof(matchCostTable)/sizeof(matchCostTable[0])-1);
(gdb) p match-matchCostTable
$1 = 2
(gdb) p (float)sizeof(matchCostTable)/sizeof(matchCostTable[0])-1
$2 = 1
(gdb) p (float)sizeof(matchCostTable)/sizeof(matchCostTable[0])
$3 = 2
(gdb) p sizeof(matchCostTable)
$4 = 8
```