### PR TITLE
Grcc and cmake failures from #378

### DIFF
--- a/tests/dockerfiles/Debian_testing.docker
+++ b/tests/dockerfiles/Debian_testing.docker
@@ -26,6 +26,9 @@ RUN cmake .. && \
     # The parallel build sometimes fails when the .grc_gnuradio
     # and .gnuradio directories do not exist
     mkdir $HOME/.grc_gnuradio/ $HOME/.gnuradio/ && \
+    # Workaround for the grcc failure
+    # https://github.com/ptrkrysik/gr-gsm/pull/378#issuecomment-379587145
+    ln -sf /usr/lib/x86_64-linux-gnu/libvolk.so.1.3.1 /usr/lib/x86_64-linux-gnu/libvolk.so.1.3 && \
     make -j $(nproc) && \
     make install && \
     ldconfig && \

--- a/tests/dockerfiles/Fedora_26.Dockerfile
+++ b/tests/dockerfiles/Fedora_26.Dockerfile
@@ -21,7 +21,7 @@ RUN cmake .. && \
         # The parallel build sometimes fails when the .grc_gnuradio
         # and .gnuradio directories do not exist
         mkdir $HOME/.grc_gnuradio/ $HOME/.gnuradio/ && \
-        make -j $(nproc) && \
+        make && \
         make install && \
         ldconfig && \
         make test

--- a/tests/dockerfiles/Kali.docker
+++ b/tests/dockerfiles/Kali.docker
@@ -26,6 +26,9 @@ RUN cmake .. && \
     # The parallel build sometimes fails when the .grc_gnuradio
     # and .gnuradio directories do not exist
     mkdir $HOME/.grc_gnuradio/ $HOME/.gnuradio/ && \
+    # Workaround for the grcc failure
+    # https://github.com/ptrkrysik/gr-gsm/pull/378#issuecomment-379587145
+    ln -sf /usr/lib/x86_64-linux-gnu/libvolk.so.1.3.1 /usr/lib/x86_64-linux-gnu/libvolk.so.1.3 && \
     make -j $(nproc) && \
     make install && \
     ldconfig && \


### PR DESCRIPTION
Fix the failures reported in https://github.com/ptrkrysik/gr-gsm/pull/378#issuecomment-379521038

```
[ 90%] Generating grgsm_livemon
Traceback (most recent call last):
  File "/usr/bin/grcc", line 29, in <module>
    from gnuradio import gr
  File "/usr/lib/python2.7/dist-packages/gnuradio/gr/__init__.py", line 41, in <module>
    from runtime_swig import *
  File "/usr/lib/python2.7/dist-packages/gnuradio/gr/runtime_swig.py", line 17, in <module>
    _runtime_swig = swig_import_helper()
  File "/usr/lib/python2.7/dist-packages/gnuradio/gr/runtime_swig.py", line 16, in swig_import_helper
    return importlib.import_module('_runtime_swig')
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
ImportError: No module named _runtime_swig
```

```
[ 0%] Built target grgsm_swig_swig_doc
Scanning dependencies of target grgsm
Scanning dependencies of target pygen_swig_72fe6
make[2]: *** No rule to make target 'swig/grgsm_swig.py', needed by 'swig/grgsm_swig.pyc'. Stop.
make[1]: *** [CMakeFiles/Makefile2:665: swig/CMakeFiles/pygen_swig_72fe6.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```