### PR TITLE
Fix ifdefs to allow compilation on FreeBSD.

### DIFF
--- a/include/grgsm/endian.h
+++ b/include/grgsm/endian.h
@@ -41,11 +41,11 @@
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
 
-#elif defined(__OpenBSD__)
+#elif defined(__OpenBSD__) || defined(__FreeBSD__)
 
 #	include <sys/endian.h>
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__NetBSD__) || defined(__DragonFly__)
 
 #	include <sys/endian.h>
 


### PR DESCRIPTION
On current version of FreeBSD (11.2) the behaviour should be exactly
the same as for OpenBSD.