### PR TITLE
Fixed TypeError

### DIFF
--- a/python/transmitter/txtime_bursts_tagger.py
+++ b/python/transmitter/txtime_bursts_tagger.py
@@ -77,7 +77,7 @@ class txtime_bursts_tagger(gr.basic_block):
           txtime_fracs = txtime_final-int(txtime_final)
           #print "txtime_secs",txtime_secs,"txtime_fracs",txtime_fracs
           tags_dict = pmt.dict_add(pmt.make_dict(), pmt.intern("tx_time"), pmt.make_tuple(pmt.from_uint64(txtime_secs),pmt.from_double(txtime_fracs)))
-          tags_dict = pmt.dict_add(tags_dict, pmt.intern("fn"), pmt.from_uint64(fn))
+          tags_dict = pmt.dict_add(tags_dict, pmt.intern("fn"), pmt.from_uint64(fn.item()))
           new_msg = pmt.cons(tags_dict, pmt.cdr(msg))
           self.message_port_pub(pmt.intern("bursts"), new_msg)
         


### PR DESCRIPTION
Converting Numpy numpy.uint64 type to int type for function pmt.from_uint64(), to prevent TypeError.