### PR TITLE
Fix grgsm_scanner -l

### DIFF
--- a/python/misc_utils/device.py
+++ b/python/misc_utils/device.py
@@ -23,11 +23,23 @@
 
 import osmosdr
 import os
+from urllib.parse import parse_qsl
+from ast import literal_eval
 
 def get_devices(hint=""):
     return osmosdr.device_find(osmosdr.device_t(hint))
 
+def device_to_dict(dev):
+    dev_dict = {}
+    for k, v in parse_qsl(dev.to_string(), separator=","):
+        try:
+            dev_dict[k] = literal_eval(v)
+        except (ValueError, SyntaxError):
+            dev_dict[k] = literal_eval(f"'{v}'")
+    return dev_dict
+
 def match(dev, filters):
+    dev = device_to_dict(dev)
     for f in filters:
         for k, v in f.items():
             if (k not in dev or dev[k] != v):


### PR DESCRIPTION
When running the command `grgsm_scanner -l`, the following exception is raised:

```
Traceback (most recent call last):
  File "/usr/bin/grgsm_scanner", line 797, in <module>
    main()
  File "/usr/bin/grgsm_scanner", line 774, in main
    gsm.device.print_devices(options.args)
  File "/usr/lib/python3/dist-packages/gnuradio/gsm/device.py", line 72, in print_devices
    devices = exclude(get_devices(hint))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/gnuradio/gsm/device.py", line 52, in exclude
    return [dev for dev in devices if not match(dev, filters)]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/gnuradio/gsm/device.py", line 52, in <listcomp>
    return [dev for dev in devices if not match(dev, filters)]
                                          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/gnuradio/gsm/device.py", line 45, in match
    if (k not in dev or dev[k] != v):
        ^^^^^^^^^^^^
TypeError: argument of type 'osmosdr.osmosdr_python.device_t' is not iterable
```
By looking at the error we can see the that issue is that `dev` is used as a if it was a `dict` but it's actually a `device_t`. This pull request adds a helper function to convert a `device_t` to a `dict` so the existing code can work as expected.

The conversion is done by using the `to_string` method which is available on objects of type `device_t` which can give strings like this: `"label='RFSPACE SDR-IQ Receiver',sdr-iq=/dev/ttyUSB0"` or this `"default_input=False,default_output=False,device_id=3,driver=audio,label='Monitor of USB Audio',soapy=2"`. Then the string is parsed into pairs of key/value using `parse_qsl` and finally the values, which are still strings at this point, are evaluated with `literal_eval` .
